### PR TITLE
fix a bug when the format date returns false instead of the formatted date string in older php versions

### DIFF
--- a/src/ZfcDatagrid/Column/Type/DateTime.php
+++ b/src/ZfcDatagrid/Column/Type/DateTime.php
@@ -191,6 +191,6 @@ class DateTime extends AbstractType
         }
         $formatter = new IntlDateFormatter($this->getLocale(), $this->getOutputDateType(), $this->getOutputTimeType(), $this->getOutputTimezone(), IntlDateFormatter::GREGORIAN, $this->getOutputPattern());
         
-        return $formatter->format($date);
+        return $formatter->format($date->getTimestamp());
     }
 }


### PR DESCRIPTION
"when formatting a DateTime object with a _custom pattern_, be sure to use a timestamp to pass at the IntlDateFormatter::format in order to have it working on different php versions"
