### PR TITLE
Move factories from module.config.php to Module.php

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -188,40 +188,6 @@ return array(
             'zfcDatagrid.examples.data.doctrine2' => 'ZfcDatagrid\Examples\Data\Doctrine2',
             'zfcDatagrid.examples.data.zendSelect' => 'ZfcDatagrid\Examples\Data\ZendSelect'
         ),
-        
-        'factories' => array(
-            
-            'zfcDatagrid' => function  (ServiceManager $serviceManager)
-            {
-                $config = $serviceManager->get('config');
-                $dataGrid = new \ZfcDatagrid\Datagrid();
-                $dataGrid->setOptions($config['ZfcDatagrid']);
-                $dataGrid->setMvcEvent($serviceManager->get('application')
-                    ->getMvcEvent());
-                if ($serviceManager->has('translator') === true) {
-                    $dataGrid->setTranslator($serviceManager->get('translator'));
-                }
-                $dataGrid->init();
-                
-                return $dataGrid;
-            },
-            
-            'zfcDatagrid_dbAdapter' => function  (ServiceManager $serviceManager)
-            {
-                $config = $serviceManager->get('config');
-                return new \Zend\Db\Adapter\Adapter($config['zfcDatagrid_dbAdapter']);
-            },
-            
-            // For the doctrine examples!
-            'doctrine.connection.orm_zfcDatagrid' => new \DoctrineORMModule\Service\DBALConnectionFactory('orm_zfcDatagrid'),
-            'doctrine.configuration.orm_zfcDatagrid' => new \DoctrineORMModule\Service\ConfigurationFactory('orm_zfcDatagrid'),
-            'doctrine.entitymanager.orm_zfcDatagrid' => new \DoctrineORMModule\Service\EntityManagerFactory('orm_zfcDatagrid'),
-            
-            'doctrine.driver.orm_zfcDatagrid' => new \DoctrineModule\Service\DriverFactory('orm_zfcDatagrid'),
-            'doctrine.eventmanager.orm_zfcDatagrid' => new \DoctrineModule\Service\EventManagerFactory('orm_zfcDatagrid'),
-            'doctrine.entity_resolver.orm_zfcDatagrid' => new \DoctrineORMModule\Service\EntityResolverFactory('orm_zfcDatagrid'),
-            'doctrine.sql_logger_collector.orm_zfcDatagrid' => new \DoctrineORMModule\Service\SQLLoggerCollectorFactory('orm_zfcDatagrid')
-        )
     ),
     
     'view_helpers' => array(

--- a/src/ZfcDatagrid/Module.php
+++ b/src/ZfcDatagrid/Module.php
@@ -4,9 +4,14 @@ namespace ZfcDatagrid;
 use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
 use Zend\ModuleManager\Feature\ConsoleUsageProviderInterface;
+use Zend\ModuleManager\Feature\ServiceProviderInterface;
 use Zend\Console\Adapter\AdapterInterface as Console;
 
-class Module implements AutoloaderProviderInterface, ConfigProviderInterface, ConsoleUsageProviderInterface
+class Module implements 
+    AutoloaderProviderInterface, 
+    ConfigProviderInterface, 
+    ConsoleUsageProviderInterface, 
+    ServiceProviderInterface
 {
 
     public function getAutoloaderConfig()
@@ -48,6 +53,45 @@ class Module implements AutoloaderProviderInterface, ConfigProviderInterface, Co
             array(
                 '--sortDir=DIRECTION',
                 'Sort direction of the columns [ASC|DESC] (split with: ,)'
+            )
+        );
+    }
+    
+    public function getServiceConfig()
+    {
+        return array(
+            'factories' => array(
+                
+                'zfcDatagrid' => function  (ServiceManager $serviceManager)
+                {
+                    $config = $serviceManager->get('config');
+                    $dataGrid = new \ZfcDatagrid\Datagrid();
+                    $dataGrid->setOptions($config['ZfcDatagrid']);
+                    $dataGrid->setMvcEvent($serviceManager->get('application')
+                        ->getMvcEvent());
+                    if ($serviceManager->has('translator') === true) {
+                        $dataGrid->setTranslator($serviceManager->get('translator'));
+                    }
+                    $dataGrid->init();
+                    
+                    return $dataGrid;
+                },
+                
+                'zfcDatagrid_dbAdapter' => function  (ServiceManager $serviceManager)
+                {
+                    $config = $serviceManager->get('config');
+                    return new \Zend\Db\Adapter\Adapter($config['zfcDatagrid_dbAdapter']);
+                },
+                
+                // For the doctrine examples!
+                'doctrine.connection.orm_zfcDatagrid' => new \DoctrineORMModule\Service\DBALConnectionFactory('orm_zfcDatagrid'),
+                'doctrine.configuration.orm_zfcDatagrid' => new \DoctrineORMModule\Service\ConfigurationFactory('orm_zfcDatagrid'),
+                'doctrine.entitymanager.orm_zfcDatagrid' => new \DoctrineORMModule\Service\EntityManagerFactory('orm_zfcDatagrid'),
+                
+                'doctrine.driver.orm_zfcDatagrid' => new \DoctrineModule\Service\DriverFactory('orm_zfcDatagrid'),
+                'doctrine.eventmanager.orm_zfcDatagrid' => new \DoctrineModule\Service\EventManagerFactory('orm_zfcDatagrid'),
+                'doctrine.entity_resolver.orm_zfcDatagrid' => new \DoctrineORMModule\Service\EntityResolverFactory('orm_zfcDatagrid'),
+                'doctrine.sql_logger_collector.orm_zfcDatagrid' => new \DoctrineORMModule\Service\SQLLoggerCollectorFactory('orm_zfcDatagrid')
             )
         );
     }


### PR DESCRIPTION
move factories to Module.php so that when we have ('config_cache_enabled' => true) then we will not face merged config errors from the functions
