### PR TITLE
Image column database url source fix, optional image width/height

### DIFF
--- a/src/ZfcDatagrid/Column/Image.php
+++ b/src/ZfcDatagrid/Column/Image.php
@@ -4,12 +4,73 @@ namespace ZfcDatagrid\Column;
 /**
  * Display images
  */
-class Image extends AbstractColumn
+class Image extends Standard
 {
+	/**
+	 * @var int
+	 */
+	private $imageHeight;
 
-    public function __construct ($uniqueId = 'image')
+	/**
+	 * @var int
+	 */
+	private $imageWidth;
+
+	/**
+	 * @param mixed $height
+	 *
+	 * return Image
+	 */
+	public function setImageHeight($height)
+	{
+		$this->imageHeight = $height;
+		return $this;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getImageHeight()
+	{
+		return $this->imageHeight;
+	}
+
+	/**
+	 * @param mixed $width
+	 *
+	 * @return Image
+	 */
+	public function setImageWidth($width)
+	{
+		$this->imageWidth = $width;
+		return $this;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getImageWidth()
+	{
+		return $this->imageWidth;
+	}
+
+	public function getImageStyleTag()
+	{
+		if (empty($this->imageWidth) && empty($this->imageHeight)) {
+			return '';
+		}
+		if (empty($this->imageHeight)) {
+			return ' style="width: ' . $this->imageWidth . 'px" ';
+		}
+		if (empty($this->imageWidth)) {
+			return ' style="height: ' . $this->imageHeight . 'px" ';
+		}
+		return ' style="height: ' . $this->imageHeight . 'px; width: ' . $this->imageWidth . 'px" ';
+	}
+
+    public function __construct($columnOrIndexOrObject = 'image', $tableOrAliasOrUniqueId = null)
     {
-        $this->setUniqueId($uniqueId);
+        parent::__construct($columnOrIndexOrObject, $tableOrAliasOrUniqueId);
         
         $this->setUserSortDisabled(true);
         $this->setUserFilterDisabled(true);

--- a/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
+++ b/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
@@ -93,7 +93,10 @@ class TableRow extends AbstractHelper
             }
             
             if ($column instanceof Column\Image) {
-                $value = ' <a href="#" class="thumbnail"><img src="' . $value . '" /></a>';
+	            /* @var Column\Image $column */
+                $value = ' <a href="#" class="thumbnail">
+                    <img src="' . $value . '" ' . $column->getImageStyleTag() . ' />
+                </a>';
             } elseif ($column instanceof Column\Action) {
                 /* @var $column \ZfcDatagrid\Column\Action */
                 $actions = array();


### PR DESCRIPTION
I made some fixes/enhancements on the Columns\Image class.
First, the class was not able to display image if the image url was a field in the database. 
Now both Gravatar (and basically DataPopulation based images) and images based on database field value work.

Second, I added the possibility to set exact width/height for the image rendered.
One can simply set image size this way:

``` php
$profileImageColumn = new Column\Image('avatarUrl', 't');
$profileImageColumn->setLabel('Avatar');
$profileImageColumn->setImageWidth(100)->setImageHeight(100);
```
