### PR TITLE
Sort with Doctrine use UniqueId insted of column alias

### DIFF
--- a/src/ZfcDatagrid/DataSource/Doctrine2.php
+++ b/src/ZfcDatagrid/DataSource/Doctrine2.php
@@ -85,7 +85,7 @@ class Doctrine2 extends AbstractDataSource
                     $qb->addSelect('ABS(' . $colString . ') sortColumn' . $key);
                     $qb->add('orderBy', new Expr\OrderBy('sortColumn' . $key, $sortCondition['sortDirection']), true);
                 } else {
-                    $qb->add('orderBy', new Expr\OrderBy($column->getUniqueId(), $sortCondition['sortDirection']), true);
+                    $qb->add('orderBy', new Expr\OrderBy($colString, $sortCondition['sortDirection']), true);
                 }
             }
         }


### PR DESCRIPTION
Sort with Doctrine use UniqueId insted of column alias
$qb->add('orderBy', new Expr\OrderBy('i_name', $sortCondition['sortDirection']), true);
instead
$qb->add('orderBy', new Expr\OrderBy('i.name', $sortCondition['sortDirection']), true);
