### PR TITLE
cellAttributes fix for #107, individual layout template fix for #106

### DIFF
--- a/src/ZfcDatagrid/Datagrid.php
+++ b/src/ZfcDatagrid/Datagrid.php
@@ -165,6 +165,8 @@ class Datagrid implements ServiceLocatorAwareInterface
      * @var array
      */
     protected $exportRenderers;
+    
+    protected $template;    
 
     protected $toolbarTemplate;
 
@@ -874,6 +876,9 @@ class Datagrid implements ServiceLocatorAwareInterface
                 }
                 $renderer->setOptions($this->getOptions());
                 $renderer->setMvcEvent($this->getMvcEvent());
+                if ($this->getTemplate() !== null) {
+                    $renderer->setTemplate($this->getTemplate());
+                }
                 if ($this->getToolbarTemplate() !== null) {
                     $renderer->setToolbarTemplate($this->getToolbarTemplate());
                 }
@@ -1077,6 +1082,27 @@ class Datagrid implements ServiceLocatorAwareInterface
         return $this->preparedData;
     }
 
+    /**
+     * Set the view template
+     *
+     * @param unknown $name
+     */
+    public function setTemplate($name)
+    {
+        $this->template = (string) $name;
+    }
+
+    /**
+     * Get the template name
+     * Return null if nothing custom set
+     *
+     * @return string null
+     */
+    public function getTemplate()
+    {
+        return $this->template;
+    }
+    
     /**
      * Set the toolbar view template
      *

--- a/src/ZfcDatagrid/Examples/Data/JqGrid/PhpArray.php
+++ b/src/ZfcDatagrid/Examples/Data/JqGrid/PhpArray.php
@@ -1,0 +1,257 @@
+<?php
+namespace ZfcDatagrid\Examples\Data\JqGrid;
+
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class PhpArray implements ServiceLocatorAwareInterface
+{
+
+    private $serviceLocator;
+
+    /**
+     * Set service locator
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     */
+    public function setServiceLocator (ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+    }
+
+    /**
+     * Get service locator
+     *
+     * @return ServiceLocatorInterface
+     */
+    public function getServiceLocator ()
+    {
+        return $this->serviceLocator;
+    }
+
+    /**
+     *
+     * @return array
+     */
+    public function getData ()
+    {
+        $data[] = array(
+            'id'      => 1,
+            'invdate' => '2010-05-24',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 10.00,
+            'total'   => 2111.00
+        );
+        $data[] = array(
+            'id'      => 2,
+            'invdate' => '2010-05-25',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 20.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 3,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 30.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 4,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 10.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 5,
+            'invdate' => '2007-10-05',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 20.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 6,
+            'invdate' => '2007-09-06',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 10.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 7,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 10.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 8,
+            'invdate' => '2007-10-03',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 9,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 11,
+            'invdate' => '2007-10-01',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 12,
+            'invdate' => '2007-10-02',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 13,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 14,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 15,
+            'invdate' => '2007-10-05',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 16,
+            'invdate' => '2007-09-06',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 17,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 18,
+            'invdate' => '2007-10-03',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 19,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 21,
+            'invdate' => '2007-10-01',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 22,
+            'invdate' => '2007-10-02',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 23,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 24,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 25,
+            'invdate' => '2007-10-05',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 26,
+            'invdate' => '2007-09-06',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 27,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 28,
+            'invdate' => '2007-10-03',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 29,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+
+        return $data;
+    }
+}

--- a/src/ZfcDatagrid/Renderer/JqGrid/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/JqGrid/Renderer.php
@@ -66,31 +66,31 @@ class Renderer extends AbstractRenderer
             $sortDirections = explode(',', $sortDirections);
 
             foreach ($sortColumns as $key => $sortColumn) {
-           		// Sometimes jqGrid creates empty strings inside sortByColumns when using groupingView
+           	// Sometimes jqGrid creates empty strings inside sortByColumns when using groupingView
             	if ($sortColumn == ' ') continue;
 
             	if (strpos($sortColumn, 'asc') !== false || strpos($sortColumn, 'desc') !== false) {
-            		list($groupSortColumn, $groupSortDirection) = explode(" ", trim($sortColumn));
+            	    list($groupSortColumn, $groupSortDirection) = explode(" ", trim($sortColumn));
 
-            		$groupSortColumns[$groupSortColumn] = $groupSortDirection;
+            	    $groupSortColumns[$groupSortColumn] = $groupSortDirection;
             	} else {
-            		// Find sortDirection for column by next `sortDirections` value
-	                $sortDirection = current($sortDirections);
+            	    // Find sortDirection for column by next `sortDirections` value
+	            $sortDirection = current($sortDirections);
 
-	                // Set default direction
-	                if ($sortDirection != 'asc' && $sortDirection != 'desc') {
-	                    $sortDirection = 'asc';
-	                }
-	                $groupSortColumns[$sortColumn] = strtoupper($sortDirection);
+	            // Set default direction
+	            if ($sortDirection != 'asc' && $sortDirection != 'desc') {
+	                $sortDirection = 'asc';
+	            }
+	            $groupSortColumns[$sortColumn] = strtoupper($sortDirection);
 
-	                next($sortDirections);
+	            next($sortDirections);
             	}
             }
 
             foreach ($this->getColumns() as $column) {
                 /* @var $column \ZfcDatagrid\Column\AbstractColumn */
             	if (key_exists($column->getUniqueId(), $groupSortColumns)) {
-            		$sortDirection = $groupSortColumns[$column->getUniqueId()];
+            	    $sortDirection = $groupSortColumns[$column->getUniqueId()];
 
                     $sortConditions[] = array(
                         'sortDirection' => $sortDirection,

--- a/src/ZfcDatagrid/Renderer/JqGrid/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/JqGrid/Renderer.php
@@ -68,11 +68,13 @@ class Renderer extends AbstractRenderer
             foreach ($sortColumns as $key => $sortColumn) {
            	// Sometimes jqGrid creates empty strings inside sortByColumns when using groupingView
             	if ($sortColumn == ' ') continue;
+            	
+            	$sortColumn = trim($sortColumn);
 
             	if (strpos($sortColumn, 'asc') !== false || strpos($sortColumn, 'desc') !== false) {
             	    list($groupSortColumn, $groupSortDirection) = explode(" ", trim($sortColumn));
 
-            	    $groupSortColumns[$groupSortColumn] = $groupSortDirection;
+            	    $groupSortColumns[$groupSortColumn] = strtoupper($groupSortDirection);
             	} else {
             	    // Find sortDirection for column by next `sortDirections` value
 	            $sortDirection = current($sortDirections);

--- a/src/ZfcDatagrid/Renderer/JqGrid/View/Helper/Columns.php
+++ b/src/ZfcDatagrid/Renderer/JqGrid/View/Helper/Columns.php
@@ -16,6 +16,13 @@ class Columns extends AbstractHelper implements ServiceLocatorAwareInterface
 
     private $translator;
 
+    private $validCellAttributes = [
+		'cellattr',
+		'sorttype',
+		'summaryType',
+		'summaryTpl'
+    ];
+    
     const STYLE_BOLD = 'cellvalue = \'<span style="font-weight: bold;">\' + cellvalue + \'</span>\';';
 
     const STYLE_ITALIC = 'cellvalue = \'<span style="font-style: italic;">\' + cellvalue + \'</span>\';';
@@ -110,6 +117,15 @@ class Columns extends AbstractHelper implements ServiceLocatorAwareInterface
             $rendererParameters = $column->getRendererParameters('jqGrid');
             if (isset($rendererParameters['cellattr'])) {
                 $options['cellattr'] = (string) $rendererParameters['cellattr'];
+            }
+            if (isset($rendererParameters['sorttype'])) {
+                $options['sorttype'] = (string) $rendererParameters['sorttype'];
+            }
+            if (isset($rendererParameters['summaryType'])) {
+                $options['summaryType'] = (string) $rendererParameters['summaryType'];
+            }
+			if (isset($rendererParameters['summaryTpl'])) {
+                $options['summaryTpl'] = (string) $rendererParameters['summaryTpl'];
             }
             
             /**

--- a/src/ZfcDatagrid/Renderer/JqGrid/View/Helper/Columns.php
+++ b/src/ZfcDatagrid/Renderer/JqGrid/View/Helper/Columns.php
@@ -17,10 +17,10 @@ class Columns extends AbstractHelper implements ServiceLocatorAwareInterface
     private $translator;
 
     private $validCellAttributes = [
-		'cellattr',
-		'sorttype',
-		'summaryType',
-		'summaryTpl'
+	'cellattr',
+	'sorttype',
+	'summaryType',
+	'summaryTpl'
     ];
     
     const STYLE_BOLD = 'cellvalue = \'<span style="font-weight: bold;">\' + cellvalue + \'</span>\';';
@@ -124,7 +124,7 @@ class Columns extends AbstractHelper implements ServiceLocatorAwareInterface
             if (isset($rendererParameters['summaryType'])) {
                 $options['summaryType'] = (string) $rendererParameters['summaryType'];
             }
-			if (isset($rendererParameters['summaryTpl'])) {
+	    if (isset($rendererParameters['summaryTpl'])) {
                 $options['summaryTpl'] = (string) $rendererParameters['summaryTpl'];
             }
             


### PR DESCRIPTION
Sorry for putting both fixes in one PR. I'm new to github usage for multiple PRs.
I guess it's best practice start a separate branches named `patch-X`, right?


Fix 1 adds the following valid `cellAttributes` to the column renderer:
- sorttype
- summaryType
- summaryTpl

Though valid strings are defined their validation is not implemented yet.

These `callattr` quickly allow the user to use jqgrid's summary feature on the `footerrow`.
See *Grouping* -> *Summary Footers* here: http://trirand.com/blog/jqgrid/jqgrid.html

Still `groupingView` parameters have to be added to the jqgrid `template`e.g.:
```javascript```
 grouping:true, groupingView : { groupField : ['name'], groupSummary : [true], groupColumnShow : [true], groupText : ['<b>{0}</b>'], groupCollapse : false, groupOrder: ['asc'] },
```

A quick fix to issue https://github.com/ThaDafinser/ZfcDatagrid/issues/107 .


Fix 2 allows the user to set an individual layout directely on the `DataGrid`:
```php
$grid = $this->getServiceLocator()->get('ZfcDatagrid\Datagrid');
$grid->setTemplate('application/index/list');
```