### PR TITLE
Added JqGrid groupingView including example

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -209,9 +209,10 @@ return array(
             'zfcDatagrid.renderer.csv' => 'ZfcDatagrid\Renderer\Csv\Renderer',
             
             // Datasources
-            'zfcDatagrid.examples.data.phpArray' => 'ZfcDatagrid\Examples\Data\PhpArray',
-            'zfcDatagrid.examples.data.doctrine2' => 'ZfcDatagrid\Examples\Data\Doctrine2',
-            'zfcDatagrid.examples.data.zendSelect' => 'ZfcDatagrid\Examples\Data\ZendSelect'
+            'zfcDatagrid.examples.data.phpArray'        => 'ZfcDatagrid\Examples\Data\PhpArray',
+            'zfcDatagrid.examples.data.doctrine2'       => 'ZfcDatagrid\Examples\Data\Doctrine2',
+            'zfcDatagrid.examples.data.zendSelect'      => 'ZfcDatagrid\Examples\Data\ZendSelect',
+        	'zfcDatagrid.examples.data.jqgrid.phpArray' => 'ZfcDatagrid\Examples\Data\JqGrid\PhpArray',
         ),
         
         'factories' => array(
@@ -239,10 +240,11 @@ return array(
         ),
         
         'template_map' => array(
-            'zfc-datagrid/renderer/bootstrapTable/layout' => __DIR__ . '/../view/zfc-datagrid/renderer/bootstrapTable/layout.phtml',
-            'zfc-datagrid/renderer/printHtml/layout' => __DIR__ . '/../view/zfc-datagrid/renderer/printHtml/layout.phtml',
-            'zfc-datagrid/renderer/printHtml/table' => __DIR__ . '/../view/zfc-datagrid/renderer/printHtml/table.phtml',
-            'zfc-datagrid/renderer/jqGrid/layout' => __DIR__ . '/../view/zfc-datagrid/renderer/jqGrid/layout.phtml'
+            'zfc-datagrid/renderer/bootstrapTable/layout'      => __DIR__ . '/../view/zfc-datagrid/renderer/bootstrapTable/layout.phtml',
+            'zfc-datagrid/renderer/printHtml/layout'           => __DIR__ . '/../view/zfc-datagrid/renderer/printHtml/layout.phtml',
+            'zfc-datagrid/renderer/printHtml/table'            => __DIR__ . '/../view/zfc-datagrid/renderer/printHtml/table.phtml',
+            'zfc-datagrid/renderer/jqGrid/layout'              => __DIR__ . '/../view/zfc-datagrid/renderer/jqGrid/layout.phtml',
+        	'zfc-datagrid/renderer/jqGrid/layout-groupingview' => __DIR__ . '/../view/zfc-datagrid/renderer/jqGrid/layout-groupingview.phtml'
         ),
         
         'template_path_stack' => array(
@@ -255,11 +257,12 @@ return array(
      */
     'controllers' => array(
         'invokables' => array(
-            'ZfcDatagrid\Examples\Controller\Person' => 'ZfcDatagrid\Examples\Controller\PersonController',
+            'ZfcDatagrid\Examples\Controller\Person'          => 'ZfcDatagrid\Examples\Controller\PersonController',
             'ZfcDatagrid\Examples\Controller\PersonDoctrine2' => 'ZfcDatagrid\Examples\Controller\PersonDoctrine2Controller',
-            'ZfcDatagrid\Examples\Controller\PersonZend' => 'ZfcDatagrid\Examples\Controller\PersonZendController',
-            'ZfcDatagrid\Examples\Controller\Minimal' => 'ZfcDatagrid\Examples\Controller\MinimalController',
-            'ZfcDatagrid\Examples\Controller\Category' => 'ZfcDatagrid\Examples\Controller\CategoryController'
+            'ZfcDatagrid\Examples\Controller\PersonZend'      => 'ZfcDatagrid\Examples\Controller\PersonZendController',
+            'ZfcDatagrid\Examples\Controller\Minimal'         => 'ZfcDatagrid\Examples\Controller\MinimalController',
+            'ZfcDatagrid\Examples\Controller\Category'        => 'ZfcDatagrid\Examples\Controller\CategoryController',
+        	'ZfcDatagrid\Examples\Controller\JqGrid'          => 'ZfcDatagrid\Examples\Controller\JqGridController',
         )
     ),
     

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -212,7 +212,7 @@ return array(
             'zfcDatagrid.examples.data.phpArray'        => 'ZfcDatagrid\Examples\Data\PhpArray',
             'zfcDatagrid.examples.data.doctrine2'       => 'ZfcDatagrid\Examples\Data\Doctrine2',
             'zfcDatagrid.examples.data.zendSelect'      => 'ZfcDatagrid\Examples\Data\ZendSelect',
-        	'zfcDatagrid.examples.data.jqgrid.phpArray' => 'ZfcDatagrid\Examples\Data\JqGrid\PhpArray',
+            'zfcDatagrid.examples.data.jqgrid.phpArray' => 'ZfcDatagrid\Examples\Data\JqGrid\PhpArray',
         ),
         
         'factories' => array(
@@ -229,7 +229,7 @@ return array(
     'view_helpers' => array(
         'invokables' => array(
             'bootstrapTableRow' => 'ZfcDatagrid\Renderer\BootstrapTable\View\Helper\TableRow',
-            'jqgridColumns' => 'ZfcDatagrid\Renderer\JqGrid\View\Helper\Columns'
+            'jqgridColumns'     => 'ZfcDatagrid\Renderer\JqGrid\View\Helper\Columns'
         )
     ),
     
@@ -244,7 +244,7 @@ return array(
             'zfc-datagrid/renderer/printHtml/layout'           => __DIR__ . '/../view/zfc-datagrid/renderer/printHtml/layout.phtml',
             'zfc-datagrid/renderer/printHtml/table'            => __DIR__ . '/../view/zfc-datagrid/renderer/printHtml/table.phtml',
             'zfc-datagrid/renderer/jqGrid/layout'              => __DIR__ . '/../view/zfc-datagrid/renderer/jqGrid/layout.phtml',
-        	'zfc-datagrid/renderer/jqGrid/layout-groupingview' => __DIR__ . '/../view/zfc-datagrid/renderer/jqGrid/layout-groupingview.phtml'
+            'zfc-datagrid/renderer/jqGrid/layout-groupingview' => __DIR__ . '/../view/zfc-datagrid/renderer/jqGrid/layout-groupingview.phtml'
         ),
         
         'template_path_stack' => array(
@@ -262,7 +262,7 @@ return array(
             'ZfcDatagrid\Examples\Controller\PersonZend'      => 'ZfcDatagrid\Examples\Controller\PersonZendController',
             'ZfcDatagrid\Examples\Controller\Minimal'         => 'ZfcDatagrid\Examples\Controller\MinimalController',
             'ZfcDatagrid\Examples\Controller\Category'        => 'ZfcDatagrid\Examples\Controller\CategoryController',
-        	'ZfcDatagrid\Examples\Controller\JqGrid'          => 'ZfcDatagrid\Examples\Controller\JqGridController',
+            'ZfcDatagrid\Examples\Controller\JqGrid'          => 'ZfcDatagrid\Examples\Controller\JqGridController',
         )
     ),
     

--- a/src/ZfcDatagrid/Examples/Controller/JqGridController
+++ b/src/ZfcDatagrid/Examples/Controller/JqGridController
@@ -1,0 +1,96 @@
+<?php
+namespace ZfcDatagrid\Examples\Controller;
+
+use Zend\Mvc\Controller\AbstractActionController;
+use ZfcDatagrid\Column;
+use ZfcDatagrid\Column\Type;
+use ZfcDatagrid\Column\Style;
+use ZfcDatagrid\Column\Formatter\Email;
+
+class JqgridController extends AbstractActionController
+{
+	/**
+	 * @see http://trirand.com/blog/jqgrid/jqgrid.html - Grouping - Grouping row(s) collapsed
+	 * @return \ZfcDatagrid\Datagrid
+	 */
+    private function getGrid()
+    {
+        /* @var $grid \ZfcDatagrid\Datagrid */
+        $grid = $this->getServiceLocator()->get('ZfcDatagrid\Datagrid');
+        $grid->setTitle('Initially hidden data');
+        $grid->setDefaultItemsPerPage(30);
+        $grid->setUserFilterDisabled(true);
+        $grid->setDataSource($this->getServiceLocator()
+            ->get('zfcDatagrid.examples.data.jqgrid.phpArray')
+            ->getData());
+
+        $col = new Column\Select('id');
+        $col->setIdentity();
+        $col->setLabel('Inv No');
+        $col->setHidden(false);
+        $grid->addColumn($col);
+
+        {
+            $colType = new Type\DateTime('Y-m-d', \IntlDateFormatter::SHORT, \IntlDateFormatter::NONE);
+            $colType->setSourceTimezone('Europe/Vienna');
+            $colType->setOutputTimezone('UTC');
+
+            $col = new Column\Select('invdate');
+            $col->setLabel('Date');
+            $col->setWidth(15);
+            $col->setType($colType);
+            $grid->addColumn($col);
+        }
+
+        $col = new Column\Select('name');
+        $col->setLabel('Client');
+        $col->setWidth(25);
+        #$col->setUserSortDisabled(true); // Prevent overwriting of `groupOrder`
+        $col->setSortDefault(1, 'ASC');
+        $grid->addColumn($col);
+
+        $colType = new Type\Number();
+        $colType->addAttribute(\NumberFormatter::FRACTION_DIGITS, 2);
+
+        $col = new Column\Select('amount');
+        $col->setLabel('Amount');
+        $col->setWidth(10);
+        $col->setType($colType);
+        $grid->addColumn($col);
+
+        $col = new Column\Select('tax');
+        $col->setLabel('Tax');
+        $col->setWidth(10);
+        $col->setType($colType);
+        $grid->addColumn($col);
+
+        $col = new Column\Select('total');
+        $col->setLabel('Total');
+        $col->setWidth(10);
+        $col->setType($colType);
+        $grid->addColumn($col);
+
+        $col = new Column\Select('note');
+        $col->setLabel('Note');
+        $col->setWidth(25);
+        $grid->addColumn($col);
+
+        return $grid;
+    }
+
+    /**
+     * JqGrid
+     *
+     * @return \ZfcDatagrid\Controller\ViewModel
+     */
+    public function groupingviewAction()
+    {
+        $grid = $this->getGrid();
+        $grid->setRendererName('jqGrid');
+        $grid->getRenderer()->setTemplate('zfc-datagrid/renderer/jqGrid/layout-groupingview');
+
+        $grid->render();
+
+        return $grid->getResponse();
+    }
+}

--- a/src/ZfcDatagrid/Examples/Data/JqGrid/PhpArray.php
+++ b/src/ZfcDatagrid/Examples/Data/JqGrid/PhpArray.php
@@ -1,0 +1,257 @@
+<?php
+namespace ZfcDatagrid\Examples\Data\JqGrid;
+
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class PhpArray implements ServiceLocatorAwareInterface
+{
+
+    private $serviceLocator;
+
+    /**
+     * Set service locator
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     */
+    public function setServiceLocator (ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+    }
+
+    /**
+     * Get service locator
+     *
+     * @return ServiceLocatorInterface
+     */
+    public function getServiceLocator ()
+    {
+        return $this->serviceLocator;
+    }
+
+    /**
+     *
+     * @return array
+     */
+    public function getData ()
+    {
+        $data[] = array(
+            'id'      => 1,
+            'invdate' => '2010-05-24',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 10.00,
+            'total'   => 2111.00
+        );
+        $data[] = array(
+            'id'      => 2,
+            'invdate' => '2010-05-25',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 20.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 3,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 30.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 4,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 10.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 5,
+            'invdate' => '2007-10-05',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 20.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 6,
+            'invdate' => '2007-09-06',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 10.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 7,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 10.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 8,
+            'invdate' => '2007-10-03',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 9,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 11,
+            'invdate' => '2007-10-01',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 12,
+            'invdate' => '2007-10-02',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 13,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 14,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 15,
+            'invdate' => '2007-10-05',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 16,
+            'invdate' => '2007-09-06',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 17,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 18,
+            'invdate' => '2007-10-03',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 19,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 21,
+            'invdate' => '2007-10-01',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 22,
+            'invdate' => '2007-10-02',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 23,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 24,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 25,
+            'invdate' => '2007-10-05',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 26,
+            'invdate' => '2007-09-06',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+        $data[] = array(
+            'id'      => 27,
+            'invdate' => '2007-10-04',
+            'name'    => 'test',
+            'note'    => 'note',
+            'tax'     => 200.00,
+            'total'   => 210.00
+        );
+        $data[] = array(
+            'id'      => 28,
+            'invdate' => '2007-10-03',
+            'name'    => 'test2',
+            'note'    => 'note2',
+            'tax'     => 300.00,
+            'total'   => 320.00
+        );
+        $data[] = array(
+            'id'      => 29,
+            'invdate' => '2007-09-01',
+            'name'    => 'test3',
+            'note'    => 'note3',
+            'tax'     => 400.00,
+            'total'   => 430.00
+        );
+
+        return $data;
+    }
+}

--- a/src/ZfcDatagrid/Renderer/JqGrid/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/JqGrid/Renderer.php
@@ -66,33 +66,33 @@ class Renderer extends AbstractRenderer
             $sortDirections = explode(',', $sortDirections);
 
             foreach ($sortColumns as $key => $sortColumn) {
-           		// Sometimes jqGrid creates empty strings inside sortByColumns when using groupingView
+           	// Sometimes jqGrid creates empty strings inside sortByColumns when using groupingView
             	if ($sortColumn == ' ') continue;
 
             	$sortColumn = trim($sortColumn);
 
             	if (strpos($sortColumn, 'asc') !== false || strpos($sortColumn, 'desc') !== false) {
-            		list($groupSortColumn, $groupSortDirection) = explode(" ", $sortColumn);
+            	    list($groupSortColumn, $groupSortDirection) = explode(" ", $sortColumn);
 
-            		$groupSortColumns[$groupSortColumn] = strtoupper($groupSortDirection);
+            	    $groupSortColumns[$groupSortColumn] = strtoupper($groupSortDirection);
             	} else {
-            		// Find sortDirection for column by next `sortDirections` value
-	                $sortDirection = current($sortDirections);
+            	    // Find sortDirection for column by next `sortDirections` value
+	            $sortDirection = current($sortDirections);
 
-	                // Set default direction
-	                if ($sortDirection != 'asc' && $sortDirection != 'desc') {
-	                    $sortDirection = 'asc';
-	                }
-	                $groupSortColumns[$sortColumn] = strtoupper($sortDirection);
+	            // Set default direction
+	            if ($sortDirection != 'asc' && $sortDirection != 'desc') {
+	                $sortDirection = 'asc';
+	            }
+	            $groupSortColumns[$sortColumn] = strtoupper($sortDirection);
 
-	                next($sortDirections);
+	            next($sortDirections);
             	}
             }
 
             foreach ($this->getColumns() as $column) {
                 /* @var $column \ZfcDatagrid\Column\AbstractColumn */
             	if (key_exists($column->getUniqueId(), $groupSortColumns)) {
-            		$sortDirection = $groupSortColumns[$column->getUniqueId()];
+            	    $sortDirection = $groupSortColumns[$column->getUniqueId()];
 
                     $sortConditions[] = array(
                         'sortDirection' => $sortDirection,

--- a/view/zfc-datagrid/renderer/jqGrid/layout-groupingview.phtml
+++ b/view/zfc-datagrid/renderer/jqGrid/layout-groupingview.phtml
@@ -1,0 +1,309 @@
+<?php
+use ZfcDatagrid\Column\Action\Button;
+use ZfcDatagrid\Filter;
+
+/* @var $paginator \Zend\Paginator\Paginator */
+$paginator = $this->paginator;
+
+$parameterNames = $this->optionsRenderer['parameterNames'];
+
+// $sortColumns = explode(',', $this->activeParameters[$parameterNames['sortColumns']]);
+// $sortDirections = explode(',', $this->activeParameters[$parameterNames['sortDirections']]);
+
+// $sortDirection = strtolower(array_pop($sortDirections));
+// $sortBys = array();
+// foreach($sortColumns as $key => $value){
+//     $sortBy = $value;
+//     if(isset($sortDirections[$key]))
+//         $sortBy .= ' '.strtolower($sortDirections[$key]);
+
+//     $sortBys[] = $sortBy;
+// }
+// $sortBys = implode(', ', $sortBys);
+
+$url = $this->url(null, array(), array(), true);
+if($this->overwriteUrl != ''){
+    $url = $this->overwriteUrl;
+}
+$parametersHtml = array();
+foreach($this->parameters as $name => $value){
+    $parametersHtml []= $name.': \''.$value.'\'';
+}
+
+$tableClasses = array();
+
+$rowClickLink = '';
+if($this->rowClickAction){
+    $tableClasses[] = 'clickable';
+
+    $rowClickLink = $this->rowClickAction->getLink();
+    if(count($this->rowClickAction->getLinkColumnPlaceholders()) > 0){
+        throw new \Exception('Currently the row click action cannot bet used with Column parameters, except the rowId...');
+    }
+}
+
+/*
+ * Column - background-color
+ */
+$styleString = '';
+foreach($this->columns as $col){
+    /* @var $col \ZfcDatagrid\Column\AbstractColumn */
+    foreach ($col->getStyles() as $style) {
+
+        switch (get_class($style)) {
+
+            case 'ZfcDatagrid\Column\Style\BackgroundColor':
+                $css = '$(\'#\' + row.idConcated).find(\'td[aria-describedby=' . $this->gridId . '_' . $col->getUniqueId() . ']\').css(\'background-color\', \'#'.$style->getRgbHexString().'\');';
+                if ($style->hasByValues() === true) {
+                    foreach ($style->getByValues() as $rule) {
+                        $colString = $rule['column']->getUniqueId();
+                        $operator = '';
+                        switch ($rule['operator']) {
+
+                            case Filter::EQUAL:
+                                $operator = '==';
+                                break;
+
+                            case Filter::NOT_EQUAL:
+                                $operator = '!=';
+                                break;
+
+                            default:
+                                throw new \Exception('currently not implemented filter type: "' . $rule['operator'] . '"');
+                                break;
+                        }
+
+                        $styleString .= 'if(row.'.$colString.' ' . $operator . ' \''. $rule['value'] . '\'){';
+                        $styleString .= $css;
+                        $styleString .= '}';
+                    }
+                } else{
+                    $styleString .= $css;
+                }
+                break;
+        }
+    }
+}
+
+/*
+ * Row coloring
+ */
+foreach($this->rowStyles as $style){
+    /* @var $style \ZfcDatagrid\Column\Style\AbstractStyle */
+
+    switch (get_class($style)) {
+
+        case 'ZfcDatagrid\Column\Style\Bold':
+            $css = '\'font-weight\', \'bold\'';
+            break;
+
+        case 'ZfcDatagrid\Column\Style\Italic':
+            $css = '\'font-style\', \'italic\'';
+            break;
+
+        case 'ZfcDatagrid\Column\Style\Color':
+            $css = '\'color\', \'#' . $style->getRgbHexString().'\'';
+            break;
+
+        case 'ZfcDatagrid\Column\Style\BackgroundColor':
+            $css = '\'background-color\', \'#' . $style->getRgbHexString().'\'';
+            break;
+
+        default:
+            throw new \Exception('Not defined yet: "' . get_class($style) . '"');
+            break;
+    }
+    $css = '$(\'#\' + row.idConcated).find(\'td\').css('.$css.');';
+
+
+    if ($style->hasByValues() === true) {
+        foreach ($style->getByValues() as $rule) {
+            $colString = $rule['column']->getUniqueId();
+            $operator = '';
+            switch ($rule['operator']) {
+
+                case Filter::EQUAL:
+                    $operator = '==';
+                    break;
+
+                case Filter::NOT_EQUAL:
+                    $operator = '!=';
+                    break;
+
+                default:
+                    throw new \Exception('currently not implemented filter type: "' . $rule['operator'] . '"');
+                    break;
+            }
+
+            $styleString .= 'if(row.'.$colString.' ' . $operator . ' \''. $rule['value'] . '\'){';
+            $styleString .= $css;
+            $styleString .= '}';
+        }
+    }  else{
+        $styleString  .= $css;
+    }
+}
+
+$itemCountPerPage = $paginator->getItemCountPerPage();
+if($paginator->getItemCountPerPage() === $paginator->getTotalItemCount()){
+    //@see http://stackoverflow.com/questions/1237096/how-to-show-all-rows-in-the-jqgrid
+    $itemCountPerPage = 1000000;
+}
+?>
+
+<?php echo $this->partial($this->templateToolbar);?>
+
+<table id="<?php echo $this->gridId; ?>" class="<?php echo implode(' ', $tableClasses); ?>"></table>
+<div id="<?php echo $this->gridId; ?>_pager"></div>
+<iframe name="<?php echo $this->gridId; ?>_fileFrame" id="<?php echo $this->gridId; ?>_fileFrame" src="about:none" style="display: none;"></iframe>
+
+<input type="hidden" id="<?php echo $this->gridId.'_'.$parameterNames['columnsHidden']; ?>" name="<?php echo $this->gridId.'_'.$parameterNames['columnsHidden']; ?>" value="<?php echo implode(',',$this->columnsHidden); ?>" />
+<input type="hidden" id="<?php echo $this->gridId.'_'.$parameterNames['columnsGroupByLocal']; ?>" name="<?php echo $this->gridId.'_'.$parameterNames['columnsGroupByLocal']; ?>" value="" />
+
+<script>
+//Row background-color + column background-color
+function grid_<?php echo $this->gridId; ?>_loadComplete(data){
+    if(data.data && data.data.rows){
+        $.each(data.data.rows, function(key, row){
+            <?php echo $styleString; ?>
+        });
+    }
+}
+
+var grid_<?php echo $this->gridId; ?>_columnsRowClickDisabled = <?php echo json_encode($this->columnsRowClickDisabled) ?>;
+
+var grid_<?php echo $this->gridId; ?> = $('#<?php echo $this->gridId; ?>').jqGrid({
+
+	url: '<?php echo $url; ?>',
+
+	caption: '<?php echo $this->title; ?>',
+
+	height: 'auto',
+	autowidth : true,
+    forceFit : true,
+    shrinkToFit : true,
+    gridview : true,
+    hoverrows : true,
+    viewrecords : true,
+
+    grouping: true,
+
+    groupingView : {
+        groupField : ['name'],
+        groupColumnShow : [true],
+        groupText : ['<b>{0} - {1} Item(s)</b>'],
+        groupCollapse : true,
+        groupOrder: ['desc']
+    },
+
+    rowNum: <?php echo $itemCountPerPage; ?>,
+
+	mtype : 'POST',
+    postData: {
+    	<?php echo $parameterNames['columnsHidden']?>: function(){
+            return $('#<?php echo $this->gridId.'_'.$parameterNames['columnsHidden']; ?>').val();
+        },
+        <?php echo $parameterNames['columnsGroupByLocal']?>: function(){
+            return $('#<?php echo $this->gridId.'_'.$parameterNames['columnsGroupByLocal']; ?>').val();
+        }
+        <?php
+        if(count($parametersHtml) > 0){
+            echo ',';
+        }
+        echo implode(',', $parametersHtml);
+        ?>
+    },
+
+	sortname: '<?php echo $this->activeParameters[$parameterNames['sortColumns']]; ?>',
+	sortorder: '<?php echo $this->activeParameters[$parameterNames['sortDirections']]; ?>',
+
+	prmNames : {
+		page: '<?php echo $parameterNames['currentPage']; ?>',
+		rows: '<?php echo $parameterNames['itemsPerPage']; ?>',
+		sort: '<?php echo $parameterNames['sortColumns']; ?>',
+		order: '<?php echo $parameterNames['sortDirections']; ?>',
+		search: '<?php echo $parameterNames['isSearch']; ?>',
+	},
+
+	pager : '#<?php echo $this->gridId; ?>_pager',
+
+    colModel: <?php echo $this->jqgridColumns($this->columns); ?>,
+
+    datatype : 'local',
+    data: {data: <?php echo json_encode($this->data); ?>},
+
+    jsonReader : {
+        repeatitems : false,
+        id : 'idConcated',
+
+        //The current page
+        page : function(data) {
+            if (data.data) {
+                return data.data.page;
+            }
+        },
+
+        records : function(data) {
+            if (data.data) {
+                return data.data.records;
+            }
+        },
+
+        total : function(data) {
+            if (data.data) {
+                return data.data.total;
+            }
+        },
+
+        //Data (rows)
+        root : function(data) {
+            if (data.data) {
+                return data.data.rows;
+            }
+        }
+    },
+
+    <?php if($rowClickLink != ''): ?>
+        onSelectRow: function(rowId, status, e){
+            var rowClickLink = '<?php echo $rowClickLink; ?>';
+            rowClickLink = rowClickLink.replace('<?php echo Button::ROW_ID_PLACEHOLDER; ?>', rowId);
+            window.location.href = rowClickLink;
+        },
+    <?php endif; ?>
+
+    <?php if($styleString != ''): ?>
+        loadComplete: function (data) {
+            if(data !== undefined){
+                //on inti we load the first page, but locale type do not know about json data
+                grid_<?php echo $this->gridId; ?>_loadComplete(data);
+            }
+        },
+    <?php endif; ?>
+
+    beforeSelectRow: function (rowId, e) {
+    	var colModel = grid_<?php echo $this->gridId; ?>.jqGrid('getGridParam','colModel');
+    	var name = colModel[$.jgrid.getCellIndex(e.target)];
+    	var colIndex = name.index;
+
+    	if (grid_<?php echo $this->gridId; ?>_columnsRowClickDisabled.colIndex) {
+            return false;
+        }
+
+        return true;
+    }
+});
+<?php if($this->isUserFilterEnabled === true):?>
+    grid_<?php echo $this->gridId; ?>.jqGrid('filterToolbar');
+<?php endif; ?>
+
+/*
+ * The first page is loaded directly without ajax, that's why it's here complicated...
+ * @todo find something "smarter"
+ */
+grid_<?php echo $this->gridId; ?>.jqGrid('setGridParam', {
+    datatype : 'json',
+}).trigger('reload');
+grid_<?php echo $this->gridId; ?>.jqGrid()[0].addJSONData(grid_<?php echo $this->gridId; ?>.jqGrid('getGridParam', 'data'));
+grid_<?php echo $this->gridId; ?>.trigger('reload');
+grid_<?php echo $this->gridId; ?>_loadComplete(grid_<?php echo $this->gridId; ?>.jqGrid('getGridParam', 'data'));
+</script>


### PR DESCRIPTION
Fixes issue https://github.com/ThaDafinser/ZfcDatagrid/issues/108

JqGrid `groupingView` example URL:
http://YOUR-PROJECT//zfcDatagrid/jqgrid/groupingview

This PR will not add `groupingView` as a new feature itself. It simply adds an example that shows how to set `groupingView` to an individual layout.

The example is based on the `JqGrid` demo:
http://trirand.com/blog/jqgrid/jqgrid.html - Grouping - Grouping row(s) collapsed

The important part is the `Renderer` that has been changed in order to allow `sorting` when using `groupingView`.

There are some differences in the behaviour of the ZfcDatagrid example and the JqGrid example when you use sorting Inv No or Date. But this should be checked later since it is no "bug".