### PR TITLE
Remove image header to view grid title

### DIFF
--- a/src/ZfcDatagrid/Renderer/TCPDF/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/TCPDF/Renderer.php
@@ -49,11 +49,6 @@ class Renderer extends AbstractExport
     {
         $pdf = $this->getPdf();
 
-        // Check for PDF image header
-        $headerData = $pdf->getHeaderData();
-        if ($headerData['logo'] == '') {
-            $pdf->setHeaderData('./tcpdf_logo.jpg');
-        }
         $pdf->AddPage();
 
         $columns = $this->getColumnsToExport();
@@ -155,7 +150,7 @@ class Renderer extends AbstractExport
             13
         ));
 
-        $pdf->setHeaderData($header['logo'], $header['logoWidth'], $this->getTitle());
+        $pdf->setHeaderData('', 0, $this->getTitle());
 
         $this->pdf = $pdf;
     }


### PR DESCRIPTION
By default a `TCPDF` logo was used as image inside the header. This logo sometimes covered the `title` or `caption` of a grid.

With this fix the "watermark" is removed and the `title` / `caption` is displayed aligned left inside the header.