### PR TITLE
Css class style for row and cell

### DIFF
--- a/src/ZfcDatagrid/Column/Style/CSSClass.php
+++ b/src/ZfcDatagrid/Column/Style/CSSClass.php
@@ -1,0 +1,56 @@
+<?php
+namespace ZfcDatagrid\Column\Style;
+
+/**
+ * Css class for the row/cell
+ */
+class CSSClass extends AbstractStyle
+{
+    private $class;
+    private $forRow;
+
+    /**
+     * @param string|array $class
+     * @param bool   $forRow
+     */
+    public function __construct($class, $forRow = false)
+    {
+        $this->class  = $class;
+        $this->forRow = $forRow;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClass()
+    {
+        if (is_array($this->class)) {
+            return implode(' ', $this->class);
+        }
+        return $this->class;
+    }
+
+    /**
+     * @param string|array $class
+     */
+    public function setClass($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getForRow()
+    {
+        return $this->forRow;
+    }
+
+    /**
+     * @param boolean $forRow
+     */
+    public function setForRow($forRow)
+    {
+        $this->forRow = (bool) $forRow;
+    }
+}

--- a/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
+++ b/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
@@ -58,16 +58,16 @@ class TableRow extends AbstractHelper implements ServiceLocatorAwareInterface
         return $name;
     }
 
-    private function getTr($row, $open = true)
+    private function getTr($row, $open = true, array $classes = null)
     {
         if ($open !== true) {
             return '</tr>';
         } else {
-
+            $class = empty($classes) ? '' : ' class="' . implode(' ' , $classes) . '"';
             if (isset($row['idConcated'])) {
-                return '<tr id="' . $row['idConcated'] . '">';
+                return '<tr' . $class . ' id="' . $row['idConcated'] . '">';
             } else {
-                return '<tr>';
+                return '<tr' . $class . '>';
             }
         }
     }
@@ -97,11 +97,8 @@ class TableRow extends AbstractHelper implements ServiceLocatorAwareInterface
      */
     public function __invoke($row, array $cols, AbstractAction $rowClickAction = null, array $rowStyles = array(), $hasMassActions = false)
     {
-        $return = $this->getTr($row);
-
-        if ($hasMassActions === true) {
-            $return .= '<td><input type="checkbox" name="massActionSelected[]" value="' . $row['id'] . '" /></td>';
-        }
+        $cells = '';
+        $rowClasses = array();
 
         foreach ($cols as $col) {
             /* @var $col \ZfcDatagrid\Column\AbstractColumn */
@@ -148,6 +145,13 @@ class TableRow extends AbstractHelper implements ServiceLocatorAwareInterface
                         case 'ZfcDatagrid\Column\Style\BackgroundColor':
                             $cssStyles[] = 'background-color: #' . $style->getRgbHexString();
                             break;
+                        case 'ZfcDatagrid\Column\Style\CSSClass':
+                            if ($style->getForRow()) {
+                                $rowClasses[] = $style->getClass();
+                            } else {
+                                $classes[] = $style->getClass();
+                            }
+                            break;
                         default:
                             throw new \InvalidArgumentException('Not defined style: "' . get_class($style) . '"');
                             break;
@@ -175,15 +179,19 @@ class TableRow extends AbstractHelper implements ServiceLocatorAwareInterface
             }
 
             $attributes = array(
-                'class' => implode(',', $classes),
+                'class' => implode(' ', $classes),
                 'style' => implode(';', $cssStyles),
                 'data-columnUniqueId' => $col->getUniqueId()
             );
 
-            $return .= $this->getTd($value, $attributes);
+            $cells .= $this->getTd($value, $attributes);
         }
 
-        $return .= $this->getTr($row, false);
+        $return = $this->getTr($row, true, $rowClasses);
+        if ($hasMassActions === true) {
+            $return .= '<td><input type="checkbox" name="massActionSelected[]" value="' . $row['id'] . '" /></td>';
+        }
+        $return .= $cells . $this->getTr($row, false);
 
         return $return;
     }

--- a/src/ZfcDatagrid/Renderer/JqGrid/View/Helper/Columns.php
+++ b/src/ZfcDatagrid/Renderer/JqGrid/View/Helper/Columns.php
@@ -266,6 +266,13 @@ class Columns extends AbstractHelper implements ServiceLocatorAwareInterface
                     $styleString = 'cellvalue = \'<span style="color: #' . $style->getRgbHexString() . ';">\' + cellvalue + \'</span>\';';
                     break;
 
+                case 'ZfcDatagrid\Column\Style\CSSClass':
+                    if ($style->getForRow()) {
+                        throw new \Exception("Currently not supporting css classes in a row!");
+                    }
+                    $styleString = 'cellvalue = \'<span class="' . $style->getClass() . '">\' + cellvalue + \'</span>\';';
+                    break;
+
                 case 'ZfcDatagrid\Column\Style\BackgroundColor':
                     // do NOTHING! this is done by loadComplete event...
                     // At this stage jqgrid haven't created the columns...

--- a/tests/ZfcDatagridTest/Column/Style/CSSClassTest.php
+++ b/tests/ZfcDatagridTest/Column/Style/CSSClassTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace ZfcDatagridTest\Column\Style;
+
+use PHPUnit_Framework_TestCase;
+use ZfcDatagrid\Column\Style\CSSClass;
+
+/**
+ * @group Column
+ * @covers ZfcDatagrid\Column\Style\CSSClass
+ */
+class CSSClassTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testConstruct()
+    {
+        $testClass = 'test-class';
+        $style = new CSSClass($testClass);
+        $this->assertEquals($testClass, $style->getClass());
+        $this->assertEquals(false, $style->getForRow());
+
+        $style = new CSSClass($testClass, true);
+        $this->assertEquals($testClass, $style->getClass());
+        $this->assertEquals(true, $style->getForRow());
+
+    }
+
+    public function testSetClass()
+    {
+        $style = new CSSClass('something');
+
+        $style->setClass('else');
+        $this->assertEquals('else', $style->getClass());
+
+        $style->setClass('another');
+        $this->assertEquals('another', $style->getClass());
+
+        $cssStyles = array('first', 'second');
+        $style->setClass($cssStyles);
+        $this->assertEquals(implode(' ', $cssStyles), $style->getClass());
+    }
+
+
+    public function testForRow()
+    {
+        $style = new CSSClass('something');
+
+        $this->assertFalse($style->getForRow());
+
+        $style->setForRow(true);
+        $this->assertTrue($style->getForRow());
+    }
+}

--- a/tests/ZfcDatagridTest/Renderer/BootstrapTable/View/Helper/TableRowTest.php
+++ b/tests/ZfcDatagridTest/Renderer/BootstrapTable/View/Helper/TableRowTest.php
@@ -147,6 +147,29 @@ class TableRowTest extends PHPUnit_Framework_TestCase
         $html = $helper($this->rowWithId, $cols);
         $this->assertContains('<td style="background-color: #00ff00"', $html);
 
+        // css class for cell
+        $myCol = clone $this->myCol;
+        $myCol->addStyle(new Style\CSSClass('test-class'));
+
+        $cols = array(
+            $myCol
+        );
+        $html = $helper($this->rowWithId, $cols);
+        $this->assertContains('<td class="test-class"', $html);
+        $this->assertNotContains('<tr class="test-class"', $html);
+
+
+        // css class for row
+        $myCol = clone $this->myCol;
+        $myCol->addStyle(new Style\CSSClass('test-class', true));
+
+        $cols = array(
+            $myCol
+        );
+        $html = $helper($this->rowWithId, $cols);
+        $this->assertContains('<tr class="test-class"', $html);
+        $this->assertNotContains('<td class="test-class"', $html);
+
         // exception
         $style = $this->getMockForAbstractClass('ZfcDatagrid\Column\Style\AbstractStyle');
 

--- a/tests/ZfcDatagridTest/Renderer/JqGrid/View/Helper/ColumnsTest.php
+++ b/tests/ZfcDatagridTest/Renderer/JqGrid/View/Helper/ColumnsTest.php
@@ -169,6 +169,38 @@ class ColumnsTest extends PHPUnit_Framework_TestCase
         $this->assertStringEndsWith('if (rowObject.myCol == \'123\') {cellvalue = \'<span style="font-weight: bold;">\' + cellvalue + \'</span>\';} return cellvalue; }}]', $result);
     }
 
+    public function testCSSClassCell()
+    {
+        $helper = new Helper\Columns();
+        $helper->setServiceLocator($this->sm);
+
+        $col1 = clone $this->myCol;
+        $col1->addStyle(new Style\CSSClass('test-class'));
+        $cols = array(
+            $col1
+        );
+
+        $result = $helper($cols);
+
+        $this->assertStringStartsWith('[{name:', $result);
+        $this->assertStringEndsWith('<span class="test-class">\' + cellvalue + \'</span>\'; return cellvalue; }}]', $result);
+    }
+
+    public function testCSSClassRow()
+    {
+        $helper = new Helper\Columns();
+        $helper->setServiceLocator($this->sm);
+
+        $col1 = clone $this->myCol;
+        $col1->addStyle(new Style\CSSClass('test-class', true));
+        $cols = array(
+            $col1
+        );
+
+        $this->setExpectedException('Exception', 'Currently not supporting css classes in a row!');
+        $result = $helper($cols);
+    }
+
     public function testStyleByValueNotEqual()
     {
         $helper = new Helper\Columns();


### PR DESCRIPTION
I needed css styling in row so made these changes to enable it.
This pull request enables css styling in bootstrap views row and cell and in the cell in jqGrid view.