### PR TITLE
Fix BootstrapTable renderer to respect column isRowClickEnabled

### DIFF
--- a/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
+++ b/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
@@ -170,7 +170,8 @@ class TableRow extends AbstractHelper implements ServiceLocatorAwareInterface
             }
 
             // "rowClick" action
-            if ($col instanceof Column\Select && $rowClickAction instanceof AbstractAction) {
+            if ($col instanceof Column\Select && $rowClickAction instanceof AbstractAction
+                    && $col->isRowClickEnabled()) {
                 $value = '<a href="' . $rowClickAction->getLinkReplaced($row) . '">' . $value . '</a>';
             }
 


### PR DESCRIPTION
It seems the setRowClickDisabled column configuration does not work for the BootstrapTable renderer and every Select column contains a link when a RowClickAction is set. This commit fixes it adding an extra verification before rendering the link.
