### PR TITLE
Mass Action - Undefined index

### DIFF
--- a/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
+++ b/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
@@ -98,7 +98,7 @@ class TableRow extends AbstractHelper implements ServiceLocatorAwareInterface
         $return = $this->getTr($row);
 
         if ($hasMassActions === true) {
-            $return .= '<td><input type="checkbox" name="massActionSelected[]" value="'.$row['id'].'" /></td>';
+            $return .= '<td><input type="checkbox" name="massActionSelected[]" value="'.$row['idConcated'].'" /></td>';
         }
 
         foreach ($cols as $col) {


### PR DESCRIPTION
Hi,

When using massAction, I receive this error:
"Notice: Undefined index: id (...)"

Because my id element has appended the table identifier <code>p_id</code>.

Should be <code>idConcated</code> instead of <code>id</code> key?

Ivo
