### PR TITLE
Allow  AbstractStyle to use other columns value to check if it should be applied.

### DIFF
--- a/docs/03. Columns.md
+++ b/docs/03. Columns.md
@@ -199,7 +199,7 @@ $col->setWidth(20);
 $col->setHidden($bool);
 
 //set this as a `primaryKey` column (all identity columns will be used together as the ID for actions and rowIds)
-$col->setIdentity($bool); 
+$col->setIdentity($bool);
 
 //set the columnType. Default is string (other types see later)
 //types also changes things: change filtering, formatting, styling ...
@@ -283,8 +283,8 @@ To use the `DateTime` column data type you need to create a `Type\DateTime` obje
 The following is an example of how to use DateTime column data type:
 ```php
 $colType = new Type\DateTime(
-        'Y-m-d H:i:s', 
-        \IntlDateFormatter::MEDIUM, 
+        'Y-m-d H:i:s',
+        \IntlDateFormatter::MEDIUM,
         \IntlDateFormatter::MEDIUM
 	);
 $colType->setSourceTimezone('UTC');
@@ -332,7 +332,7 @@ $colTags->setLabel('Tags');
 $colTags->setType(new Type\PhpArray());
 ```
 You can change the separator by one of the following ways:
-```php 
+```php
 new Type\PhpArray(',');
 ```
 ```php
@@ -396,6 +396,12 @@ $style->addByValue($col, 20, Filter::GREATER_EQUAL);
 $style->addByValue($col, 40, Filter::LESS_EQUAL);
 ```
 
+You can also use another column's value to make the comparison:
+```php
+$style = new Style\Color(Style\Color::$GREEN);
+//Apply only when the value of the column $colPaid is greater or equal than the value of the column $colDue
+$style->addByValue($colPaid, $colDue, Filter::GREATER_EQUAL);
+```
 
 ## Column Data Formatters
 The column data formatters are custom formatters used to format the value from the datasource to be displayed in the grid table.

--- a/src/ZfcDatagrid/Column/Style/AbstractStyle.php
+++ b/src/ZfcDatagrid/Column/Style/AbstractStyle.php
@@ -109,7 +109,13 @@ abstract class AbstractStyle
                 $value = $row[$rule['column']->getUniqueId()];
             }
 
-            $isApplyMatch = Filter::isApply($value, $rule['value'], $rule['operator']);
+            if ($rule['value'] instanceof AbstractColumn && isset($row[$rule['value']->getUniqueId()])) {
+                $ruleValue = $row[$rule['value']->getUniqueId()];
+            } else {
+                $ruleValue = $rule['value'];
+            }
+
+            $isApplyMatch = Filter::isApply($value, $ruleValue, $rule['operator']);
             if ($this->getByValueOperator() == 'OR' && true === $isApplyMatch) {
                 // For OR one match is enough
                 return true;

--- a/src/ZfcDatagrid/Column/Style/AbstractStyle.php
+++ b/src/ZfcDatagrid/Column/Style/AbstractStyle.php
@@ -109,8 +109,12 @@ abstract class AbstractStyle
                 $value = $row[$rule['column']->getUniqueId()];
             }
 
-            if ($rule['value'] instanceof AbstractColumn && isset($row[$rule['value']->getUniqueId()])) {
-                $ruleValue = $row[$rule['value']->getUniqueId()];
+            if ($rule['value'] instanceof AbstractColumn) {
+                 if (isset($row[$rule['value']->getUniqueId()])) {
+                    $ruleValue = $row[$rule['value']->getUniqueId()];
+                } else {
+                    $ruleValue = '';
+                }
             } else {
                 $ruleValue = $rule['value'];
             }

--- a/tests/ZfcDatagridTest/Column/Style/AbstractStyleTest.php
+++ b/tests/ZfcDatagridTest/Column/Style/AbstractStyleTest.php
@@ -179,4 +179,44 @@ class AbstractStyleTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException('InvalidArgumentException');
         $style->setByValueOperator('XOR');
     }
+
+    public function testStyleByColumn()
+    {
+        /* @var $style \ZfcDatagrid\Column\Style\AbstractStyle */
+        $style = $this->getMockForAbstractClass('ZfcDatagrid\Column\Style\AbstractStyle');
+
+        $columnCompare = clone $this->column;
+        $columnCompare->setUniqueId('columnCompare');
+
+        $style->addByValue($this->column, $columnCompare, Filter::GREATER_EQUAL);
+        $this->assertEquals([
+            [
+                'column'   => $this->column,
+                'value'    => $columnCompare,
+                'operator' => Filter::GREATER_EQUAL,
+            ],
+        ], $style->getByValues());
+
+        $this->assertTrue($style->hasByValues());
+
+        // Test lower value
+        $row = [
+            $this->column->getUniqueId() => 5,
+            $columnCompare->getUniqueId() => 15,
+        ];
+        $this->assertFalse($style->isApply($row));
+
+        // Test greater value
+        $row = [
+            $this->column->getUniqueId() => 15,
+            $columnCompare->getUniqueId() => 10,
+        ];
+        $this->assertTrue($style->isApply($row));
+
+        // Test row without compared column
+        $row = [
+            $this->column->getUniqueId() => 15,
+        ];
+        $this->assertTrue($style->isApply($row));
+    }
 }


### PR DESCRIPTION
This PR changes AbstractStyle so that you can pass another Column to $value, if so the style will use this column's  value to determine if it should be applied. 

With that it you can, for example, change the color of a row to green if the column valuePaid >= valueDue