### PR TITLE
remove unnecessary parameters

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -79,9 +79,6 @@ return [
                     'sortDirections' => 'sortDirections',
                     'isSearch'       => 'isSearch',
 
-                    'columnsHidden'       => 'columnsHidden',
-                    'columnsGroupByLocal' => 'columnsGroupBy',
-
                     'massIds' => 'ids',
                 ],
             ],

--- a/src/ZfcDatagrid/Renderer/AbstractRenderer.php
+++ b/src/ZfcDatagrid/Renderer/AbstractRenderer.php
@@ -662,13 +662,6 @@ abstract class AbstractRenderer implements RendererInterface
         $viewModel->setVariable('generalParameterNames', $generalParameterNames);
 
         $viewModel->setVariable('columns', $this->getColumns());
-        $columnsHidden = [];
-        foreach ($this->getColumns() as $column) {
-            if ($column->isHidden()) {
-                $columnsHidden[] = $column->getUniqueId();
-            }
-        }
-        $viewModel->setVariable('columnsHidden', $columnsHidden);
 
         $viewModel->setVariable('rowStyles', $grid->getRowStyles());
 

--- a/view/zfc-datagrid/renderer/jqGrid/layout.phtml
+++ b/view/zfc-datagrid/renderer/jqGrid/layout.phtml
@@ -152,9 +152,6 @@ if($paginator->getItemCountPerPage() === $paginator->getTotalItemCount()){
 
 <iframe name="<?php echo $this->gridId; ?>_fileFrame" id="<?php echo $this->gridId; ?>_fileFrame" src="about:none" style="display: none;"></iframe>
 
-<input type="hidden" id="<?php echo $this->gridId.'_'.$parameterNames['columnsHidden']; ?>" name="<?php echo $this->gridId.'_'.$parameterNames['columnsHidden']; ?>" value="<?php echo implode(',',$this->columnsHidden); ?>" />
-<input type="hidden" id="<?php echo $this->gridId.'_'.$parameterNames['columnsGroupByLocal']; ?>" name="<?php echo $this->gridId.'_'.$parameterNames['columnsGroupByLocal']; ?>" value="" />
-
 <?php $this->inlineScript()->captureStart(); ?>
 
 //Row background-color + column background-color
@@ -190,16 +187,7 @@ var grid_<?php echo $this->gridId; ?> = $('#<?php echo $this->gridId; ?>').jqGri
 
 	mtype : 'POST',
     postData: {
-    	<?php echo $parameterNames['columnsHidden']?>: function(){
-            return $('#<?php echo $this->gridId.'_'.$parameterNames['columnsHidden']; ?>').val();
-        },
-        <?php echo $parameterNames['columnsGroupByLocal']?>: function(){
-            return $('#<?php echo $this->gridId.'_'.$parameterNames['columnsGroupByLocal']; ?>').val();
-        }
         <?php
-        if(count($parametersHtml) > 0){
-            echo ',';
-        }
         echo implode(',', $parametersHtml);
         ?>
     },


### PR DESCRIPTION
Following issue happened:
- an advanced filter with many fields
- IE11 cutted off the url because it was too long

So i removed the 2 paramters, since they were never used until yet