### PR TITLE
Dynamic action label, based on row value of another column

### DIFF
--- a/src/ZfcDatagrid/Column/Action/AbstractAction.php
+++ b/src/ZfcDatagrid/Column/Action/AbstractAction.php
@@ -17,6 +17,12 @@ abstract class AbstractAction
 
     /**
      *
+     * @var \ZfcDatagrid\Column\AbstractColumn
+     */
+    protected $useValueOfColAsLabel = false;
+
+    /**
+     *
      * @var array
      */
     protected $htmlAttributes = [];
@@ -51,6 +57,42 @@ abstract class AbstractAction
     public function getLink()
     {
         return $this->getAttribute('href');
+    }
+
+
+    /**
+     * Use the row-value of the column supplied for this action
+     *
+     * @param AbstractColumn $col
+     * @return AbstractAction|AbstractColumn|FALSE
+     */
+    public function useValueOfColAsLabel($col = false) {
+        
+        /*
+         * if column is supplied, set it
+         */
+        if ($col instanceof AbstractColumn) {
+            $this->useValueOfColAsLabel = $col;
+            return $this; //let's be fluid
+        }
+
+        /*
+         * if useValueOfColAsLabel hasn't been set,
+         * then it shouldn't be replace so return false
+         */
+        if ($this->useValueOfColAsLabel === false) {
+            return false;
+        }
+
+        /*
+         * if column has been set return it and $col is not supplied
+         */
+        if ($this->useValueOfColAsLabel instanceof AbstractColumn && $col === false) {
+            return $this->useValueOfColAsLabel;
+        } 
+        
+        throw new \InvalidArgumentException('$col has to be an instance of ZfcDatagrid\Column\AbstractColumn or left blank');
+
     }
 
     /**

--- a/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
+++ b/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
@@ -171,6 +171,16 @@ class TableRow extends AbstractHelper implements ServiceLocatorAwareInterface
                 foreach ($col->getActions() as $action) {
                     /* @var $action \ZfcDatagrid\Column\Action\AbstractAction */
                     if ($action->isDisplayed($row) === true) {
+			
+			if (($colToUse = $action->useValueOfColAsLabel()) !== false) {
+
+                            $newLabel = $row[$colToUse->getUniqueId()];
+                            //no label => no action
+                            if ($newLabel == '') {
+                                continue;
+                            }
+                            $action->setLabel($newLabel);
+                        }
                         $action->setTitle($this->translate($action->getTitle()));
                         $actions[] = $action->toHtml($row);
                     }


### PR DESCRIPTION
Could be an alternative to issue #74 

Now you can define an action as you are used to and make this action label with the value of another column. 

e.g. 
you have a table

| ID | Issue | Creator |
|---|---|---|
| 1 | Bugfix | Someone |
| 2 | Feature | anotherOne |


And you doen want want to have your links with actions like

| ID | Issue | Creator | IssueAction | CreatorAction | 
|---|---|---|---|---|
| 1 | Bugfix | Someone | [viewIssue](#) | [viewCreator](#)  |
| 2 | Feature | anotherOne | [viewIssue](#) | [viewCreator](#)  |

you can tell the action to make use of the value in another column 

| ID | Issue | Creator | IssueAction | CreatorAction | 
|---|---|---|---|---|
| 1 | Bugfix | Someone | [Bugfix](#) | [Someone](#)  |
| 2 | Feature | anotherOne | [Feature](#) | [anotherOne](#)  |

now hide the other value-providing columns

| ID | IssueAction | CreatorAction | 
|---|---|---|
| 1 | [Bugfix](#) | [Someone](#)  |
| 2 | [Feature](#) | [anotherOne](#)  |

Tadaaaa ;)


Has definitely room for improvements like setting the providing column hidden automatically but it's a beginning and could already be useful for others

While I additionally wanted to copy the Filter and Sorting of the providing column I'm lacking time. 
So I used this workaround in my layout.phtml
(I know it's redundant, but did I mention my lack of time?)
```php
if ($col->isUserFilterEnabled() === true) {
    //[...] original part 
}
if ($col instanceof \ZfcDatagrid\Column\Action) {

    foreach ($col->getActions() as $action) {

        if (($col = $action->useValueOfColAsLabel())) {
            if ($col->isUserFilterEnabled() === true) {

                if ($col->hasFilterSelectOptions() === true) {
                    $htmlFilter .= '<select name="toolbarFilters[' . $col->getUniqueId() . ']" style="width: 80%" onchange="this.form.submit()" class="form-control" >';
                    foreach ($col->getFilterSelectOptions() as $value => $option) {
                        if ($col->getFilterActiveValue() == sprintf($col->getFilterDefaultOperation(), $value)) {
                            $htmlFilter .= '<option value="' . $value . '" selected="selected">' . $option . '</option>';
                        } else if (($col->getFilterActiveValue() === '') && ($value === '')) {
                            $htmlFilter .= '<option value="' . $value . '" selected="selected">' . $option . '</option>';
                        } else {
                            $htmlFilter .= '<option value="' . $value . '">' . $option . '</option>';
                        }
                    }
                    $htmlFilter .= '</select>';
                } else if ($col->getType() instanceof \ZfcDatagrid\Column\Type\DateTime) {
                    $htmlFilter .= '<input type="text" name="toolbarFilters[' . $col->getUniqueId() . ']" style="width: 80%" value="' . $col->getFilterActiveValue() . '" class="form-control daterange" />';
                } else {
                    $htmlFilter .= '<input type="text" name="toolbarFilters[' . $col->getUniqueId() . ']" style="width: 80%" value="' . $col->getFilterActiveValue() . '" class="form-control" />';
                }
            }
        }
    }
}
```