### PR TITLE
Fix const declatation style align

### DIFF
--- a/src/ZfcDatagrid/Column/Action/AbstractAction.php
+++ b/src/ZfcDatagrid/Column/Action/AbstractAction.php
@@ -17,6 +17,12 @@ abstract class AbstractAction
 
     /**
      *
+     * @var \ZfcDatagrid\Column\AbstractColumn
+     */
+    protected $useValueOfColAsLabel = false;
+
+    /**
+     *
      * @var array
      */
     protected $htmlAttributes = [];
@@ -51,6 +57,42 @@ abstract class AbstractAction
     public function getLink()
     {
         return $this->getAttribute('href');
+    }
+
+
+    /**
+     * Use the row-value of the column supplied for this action
+     *
+     * @param AbstractColumn $col
+     * @return AbstractAction|AbstractColumn|FALSE
+     */
+    public function useValueOfColAsLabel($col = false) {
+        
+        /*
+         * if column is supplied, set it
+         */
+        if ($col instanceof AbstractColumn) {
+            $this->useValueOfColAsLabel = $col;
+            return $this; //let's be fluid
+        }
+
+        /*
+         * if useValueOfColAsLabel hasn't been set,
+         * then it shouldn't be replace so return false
+         */
+        if ($this->useValueOfColAsLabel === false) {
+            return false;
+        }
+
+        /*
+         * if column has been set return it and $col is not supplied
+         */
+        if ($this->useValueOfColAsLabel instanceof AbstractColumn && $col === false) {
+            return $this->useValueOfColAsLabel;
+        } 
+        
+        throw new \InvalidArgumentException('$col has to be an instance of ZfcDatagrid\Column\AbstractColumn or left blank');
+
     }
 
     /**

--- a/src/ZfcDatagrid/Column/Style/Align.php
+++ b/src/ZfcDatagrid/Column/Style/Align.php
@@ -7,25 +7,25 @@ class Align extends AbstractStyle
      *
      * @var string
      */
-    public static $LEFT = 'left';
+    const $LEFT = 'left';
 
     /**
      *
      * @var string
      */
-    public static $RIGHT = 'right';
+    const $RIGHT = 'right';
 
     /**
      *
      * @var string
      */
-    public static $CENTER = 'center';
+    const $CENTER = 'center';
 
     /**
      *
      * @var string
      */
-    public static $JUSTIFY = 'justify';
+    const $JUSTIFY = 'justify';
 
     /**
      *

--- a/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
+++ b/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
@@ -171,6 +171,16 @@ class TableRow extends AbstractHelper implements ServiceLocatorAwareInterface
                 foreach ($col->getActions() as $action) {
                     /* @var $action \ZfcDatagrid\Column\Action\AbstractAction */
                     if ($action->isDisplayed($row) === true) {
+			
+			if (($colToUse = $action->useValueOfColAsLabel()) !== false) {
+
+                            $newLabel = $row[$colToUse->getUniqueId()];
+                            //no label => no action
+                            if ($newLabel == '') {
+                                continue;
+                            }
+                            $action->setLabel($newLabel);
+                        }
                         $action->setTitle($this->translate($action->getTitle()));
                         $actions[] = $action->toHtml($row);
                     }


### PR DESCRIPTION
I stumbled over this error when I tried to set the alignment with:

```php
$style = new Column\Style\Align();
$style->setAlignment(Column\Style\Align::RIGHT);
```

Without my fix it's only possible this way:

```php
$style = new Column\Style\Align('right');
```


