### PR TITLE
unittests update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.2",
-        "fabpot/php-cs-fixer": "^1.11",
+        "friendsofphp/php-cs-fixer": "^1.11",
         
         "doctrine/orm": ">=2.5,<2.7",
         "doctrine/dbal": ">=2.5,<2.7",

--- a/src/ZfcDatagrid/Column/Style/Color.php
+++ b/src/ZfcDatagrid/Column/Style/Color.php
@@ -4,7 +4,6 @@
  * general or based on a value
  *
  */
-
 namespace ZfcDatagrid\Column\Style;
 
 class Color extends AbstractColor

--- a/src/ZfcDatagrid/Column/Type/Image.php
+++ b/src/ZfcDatagrid/Column/Type/Image.php
@@ -2,7 +2,6 @@
 /**
  * Image type
  */
-
 namespace ZfcDatagrid\Column\Type;
 
 use InvalidArgumentException;

--- a/src/ZfcDatagrid/DataSource/Doctrine2/Paginator.php
+++ b/src/ZfcDatagrid/DataSource/Doctrine2/Paginator.php
@@ -4,7 +4,6 @@
  * or if we use the "safe" variant by Doctrine2
  *
  */
-
 namespace ZfcDatagrid\DataSource\Doctrine2;
 
 use Doctrine\ORM\QueryBuilder;

--- a/src/ZfcDatagrid/PrepareData.php
+++ b/src/ZfcDatagrid/PrepareData.php
@@ -221,7 +221,7 @@ class PrepareData
                  */
                 if (is_array($row[$col->getUniqueId()])) {
                     array_walk_recursive($row[$col->getUniqueId()], function (&$value) {
-                        if(!is_object($value)){
+                        if (!is_object($value)) {
                             $value = trim($value);
                         }
                     });

--- a/src/ZfcDatagrid/Renderer/AbstractExport.php
+++ b/src/ZfcDatagrid/Renderer/AbstractExport.php
@@ -3,7 +3,6 @@
  * Methods which can be used in (all) export renderer
  *
  */
-
 namespace ZfcDatagrid\Renderer;
 
 use ZfcDatagrid\Column;

--- a/src/ZfcDatagrid/Renderer/Csv/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/Csv/Renderer.php
@@ -3,7 +3,6 @@
  * Render datagrid as CSV
  *
  */
-
 namespace ZfcDatagrid\Renderer\Csv;
 
 use Zend\Http\Headers;

--- a/src/ZfcDatagrid/Renderer/PHPExcel/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/PHPExcel/Renderer.php
@@ -2,7 +2,6 @@
 /**
  * Output as an excel file
  */
-
 namespace ZfcDatagrid\Renderer\PHPExcel;
 
 use PHPExcel;

--- a/src/ZfcDatagrid/Renderer/TCPDF/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/TCPDF/Renderer.php
@@ -2,7 +2,6 @@
 /**
  * Output as a PDF file
  */
-
 namespace ZfcDatagrid\Renderer\TCPDF;
 
 use TCPDF;

--- a/tests/ZfcDatagridTest/Column/Action/AbstractActionTest.php
+++ b/tests/ZfcDatagridTest/Column/Action/AbstractActionTest.php
@@ -206,21 +206,25 @@ class AbstractActionTest extends PHPUnit_Framework_TestCase
         ]));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testSetShowOnValueOperatorException()
     {
         /* @var $action \ZfcDatagrid\Column\Action\AbstractAction */
         $action = $this->getMockForAbstractClass('ZfcDatagrid\Column\Action\AbstractAction');
 
-        $this->setExpectedException('InvalidArgumentException');
         $action->setShowOnValueOperator('XOR');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testIsDisplayedException()
     {
         /* @var $action \ZfcDatagrid\Column\Action\AbstractAction */
         $action = $this->getMockForAbstractClass('ZfcDatagrid\Column\Action\AbstractAction');
 
-        $this->setExpectedException('InvalidArgumentException');
         $action->addShowOnValue($this->column, '23', 'UNknownFilter');
         $action->isDisplayed([
             $this->column->getUniqueId() => '32',

--- a/tests/ZfcDatagridTest/Column/Action/ButtonTest.php
+++ b/tests/ZfcDatagridTest/Column/Action/ButtonTest.php
@@ -45,11 +45,13 @@ class ButtonTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($html, $button->toHtml(['myCol' => 'Blubb']));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testHtmlException()
     {
         $button = new Button();
 
-        $this->setExpectedException('InvalidArgumentException');
         $button->toHtml([]);
     }
 }

--- a/tests/ZfcDatagridTest/Column/Action/IconTest.php
+++ b/tests/ZfcDatagridTest/Column/Action/IconTest.php
@@ -45,11 +45,12 @@ class IconTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<a href="#"><img src="/images/21/add.png" /></a>', $icon->toHtml([]));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testException()
     {
         $icon = new Icon();
-
-        $this->setExpectedException('InvalidArgumentException');
 
         $icon->toHtml([]);
     }

--- a/tests/ZfcDatagridTest/Column/ActionTest.php
+++ b/tests/ZfcDatagridTest/Column/ActionTest.php
@@ -27,14 +27,14 @@ class ActionTest extends PHPUnit_Framework_TestCase
 
         $this->assertCount(0, $column->getActions());
 
-        $action = $this->getMock('ZfcDatagrid\Column\Action\Button');
+        $action = $this->getMockBuilder('ZfcDatagrid\Column\Action\Button')->getMock();
         $column->addAction($action);
 
         $this->assertCount(1, $column->getActions());
 
-        $action2 = $this->getMock('ZfcDatagrid\Column\Action\Button');
+        $action2 = $this->getMockBuilder('ZfcDatagrid\Column\Action\Button')->getMock();
         $column->addAction($action2);
-        $action3 = $this->getMock('ZfcDatagrid\Column\Action\Button');
+        $action3 = $this->getMockBuilder('ZfcDatagrid\Column\Action\Button')->getMock();
         $column->addAction($action3);
 
         $this->assertCount(3, $column->getActions());
@@ -43,8 +43,8 @@ class ActionTest extends PHPUnit_Framework_TestCase
         $this->assertCount(2, $column->getActions());
 
         $actions = [
-            $this->getMock('ZfcDatagrid\Column\Action\Button'),
-            $this->getMock('ZfcDatagrid\Column\Action\Button'),
+            $this->getMockBuilder('ZfcDatagrid\Column\Action\Button')->getMock(),
+            $this->getMockBuilder('ZfcDatagrid\Column\Action\Button')->getMock(),
         ];
         $column->setActions($actions);
         $this->assertEquals($actions, $column->getActions());

--- a/tests/ZfcDatagridTest/Column/DataPopulation/Object/GravatarTest.php
+++ b/tests/ZfcDatagridTest/Column/DataPopulation/Object/GravatarTest.php
@@ -22,11 +22,13 @@ class GravatarTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.gravatar.com/avatar/' . md5('martin.keckeis1@gmail.com'), $gravatar->toString());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testException()
     {
         $gravatar = new Gravatar();
 
-        $this->setExpectedException('InvalidArgumentException');
         $gravatar->setParameterFromColumn('invalidPara', 'someValue');
     }
 }

--- a/tests/ZfcDatagridTest/Column/DataPopulation/ObjectTest.php
+++ b/tests/ZfcDatagridTest/Column/DataPopulation/ObjectTest.php
@@ -12,7 +12,7 @@ class ObjectTest extends PHPUnit_Framework_TestCase
 {
     public function testObject()
     {
-        $mock = $this->getMock('ZfcDatagrid\Column\DataPopulation\Object\Gravatar');
+        $mock = $this->getMockBuilder('ZfcDatagrid\Column\DataPopulation\Object\Gravatar')->getMock();
         $mock->expects($this->any())
             ->method('toString')
             ->will($this->returnValue('myReturn'));
@@ -28,7 +28,7 @@ class ObjectTest extends PHPUnit_Framework_TestCase
     public function testParameters()
     {
         $column = $this->getMockForAbstractClass('ZfcDatagrid\Column\AbstractColumn');
-        $mock   = $this->getMock('ZfcDatagrid\Column\DataPopulation\Object\Gravatar');
+        $mock   = $this->getMockBuilder('ZfcDatagrid\Column\DataPopulation\Object\Gravatar')->getMock();
         $mock->expects($this->any())
         ->method('toString')
         ->will($this->returnValue('myReturn'));

--- a/tests/ZfcDatagridTest/Column/ExternalDataTest.php
+++ b/tests/ZfcDatagridTest/Column/ExternalDataTest.php
@@ -21,11 +21,12 @@ class ExternalDataTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($col->isUserSortEnabled());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testGetDataPopulationException()
     {
         $col = new Column\ExternalData('myData');
-
-        $this->setExpectedException('InvalidArgumentException');
 
         $col->getDataPopulation();
     }
@@ -44,12 +45,14 @@ class ExternalDataTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZfcDatagrid\Column\DataPopulation\Object', $col->getDataPopulation());
     }
 
+    /**
+     * @expectedException \Exception
+     */
     public function testException()
     {
         $col = new Column\ExternalData('myData');
 
         $object = new DataPopulation\Object();
-        $this->setExpectedException('Exception');
         $col->setDataPopulation($object);
     }
 }

--- a/tests/ZfcDatagridTest/Column/SelectTest.php
+++ b/tests/ZfcDatagridTest/Column/SelectTest.php
@@ -45,18 +45,20 @@ class SelectTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('myAlias', $col->getUniqueId());
     }
 
+    /**
+     * @expectedException \Exception
+     */
     public function testException()
     {
-        $this->setExpectedException('Exception');
-
         $expr = new \Zend\Db\Sql\Expression('Something...');
         $col  = new Column\Select($expr);
     }
 
+    /**
+     * @expectedException \Exception
+     */
     public function testExceptionNotString()
     {
-        $this->setExpectedException('Exception');
-
         $expr = new \Zend\Db\Sql\Expression('Something...');
         $col  = new Column\Select($expr, new \stdClass());
     }

--- a/tests/ZfcDatagridTest/Column/Style/AbstractStyleTest.php
+++ b/tests/ZfcDatagridTest/Column/Style/AbstractStyleTest.php
@@ -158,12 +158,14 @@ class AbstractStyleTest extends PHPUnit_Framework_TestCase
         ]));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testSetByValueOperatorException()
     {
         /* @var $style \ZfcDatagrid\Column\Style\AbstractStyle */
         $style = $this->getMockForAbstractClass('ZfcDatagrid\Column\Style\AbstractStyle');
 
-        $this->setExpectedException('InvalidArgumentException');
         $style->setByValueOperator('XOR');
     }
 

--- a/tests/ZfcDatagridTest/DataSource/AbstractDataSourceTest.php
+++ b/tests/ZfcDatagridTest/DataSource/AbstractDataSourceTest.php
@@ -87,7 +87,8 @@ class AbstractDataSourceTest extends PHPUnit_Framework_TestCase
     {
         $ds = clone $this->dsMock;
 
-        $filter = $this->getMock('ZfcDatagrid\Filter');
+        $filter = $this->getMockBuilder('ZfcDatagrid\Filter')
+            ->getMock();
         $ds->addFilter($filter);
 
         $this->assertEquals([
@@ -99,7 +100,8 @@ class AbstractDataSourceTest extends PHPUnit_Framework_TestCase
     {
         $ds = clone $this->dsMock;
 
-        $adapter = $this->getMock('Zend\Paginator\Adapter\ArrayAdapter');
+        $adapter = $this->getMockBuilder('Zend\Paginator\Adapter\ArrayAdapter')
+            ->getMock();
         $ds->setPaginatorAdapter($adapter);
 
         $this->assertInstanceOf('Zend\Paginator\Adapter\AdapterInterface', $ds->getPaginatorAdapter());

--- a/tests/ZfcDatagridTest/DataSource/Doctrine2/FilterTest.php
+++ b/tests/ZfcDatagridTest/DataSource/Doctrine2/FilterTest.php
@@ -314,9 +314,13 @@ class FilterTest extends AbstractDoctrine2Test
         $this->assertEquals('789', $parameters[1]->getValue());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testException()
     {
-        $filter = $this->getMock('ZfcDatagrid\Filter');
+        $filter = $this->getMockBuilder('ZfcDatagrid\Filter')
+            ->getMock();
         $filter->expects($this->any())
             ->method('getColumn')
             ->will($this->returnValue($this->colVolumne));
@@ -329,7 +333,6 @@ class FilterTest extends AbstractDoctrine2Test
             ->method('getOperator')
             ->will($this->returnValue(' () '));
 
-        $this->setExpectedException('InvalidArgumentException');
         $filterDoctrine2 = clone $this->filterDoctrine2;
         $filterDoctrine2->applyFilter($filter);
     }

--- a/tests/ZfcDatagridTest/DataSource/Doctrine2/Mocks/EntityManagerMock.php
+++ b/tests/ZfcDatagridTest/DataSource/Doctrine2/Mocks/EntityManagerMock.php
@@ -18,7 +18,6 @@
  * and is licensed under the LGPL. For more information, see
  * <http://www.doctrine-project.org>.
  */
-
 namespace ZfcDatagridTest\DataSource\Doctrine2\Mocks;
 
 /**

--- a/tests/ZfcDatagridTest/DataSource/Doctrine2CollectionTest.php
+++ b/tests/ZfcDatagridTest/DataSource/Doctrine2CollectionTest.php
@@ -40,15 +40,21 @@ class Doctrine2CollectionTest extends DataSourceTestCase
         $this->source = $source;
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown data input: "instanceof stdClass"
+     */
     public function testConstructException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Unknown data input: "instanceof stdClass"');
         $source = new Doctrine2Collection(new \stdClass());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown data input: ""
+     */
     public function testConstructExceptionClass()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Unknown data input: ""');
         $source = new Doctrine2Collection(null);
     }
 
@@ -61,7 +67,9 @@ class Doctrine2CollectionTest extends DataSourceTestCase
 
     public function testEntityManager()
     {
-        $em = $this->getMock('Doctrine\ORM\EntityManager', [], [], '', false);
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $source = clone $this->source;
         $this->assertNull($source->getEntityManager());

--- a/tests/ZfcDatagridTest/DataSource/Doctrine2Test.php
+++ b/tests/ZfcDatagridTest/DataSource/Doctrine2Test.php
@@ -33,6 +33,9 @@ class Doctrine2Test extends AbstractDoctrine2Test
         ]);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testConstruct()
     {
         $source = clone $this->source;
@@ -40,7 +43,6 @@ class Doctrine2Test extends AbstractDoctrine2Test
         $this->assertInstanceOf('Doctrine\ORM\QueryBuilder', $source->getData());
         $this->assertSame($this->qb, $source->getData());
 
-        $this->setExpectedException('InvalidArgumentException');
         $source = new Doctrine2(new \stdClass('something'));
     }
 

--- a/tests/ZfcDatagridTest/DataSource/PhpArray/FilterTest.php
+++ b/tests/ZfcDatagridTest/DataSource/PhpArray/FilterTest.php
@@ -26,7 +26,8 @@ class FilterTest extends PHPUnit_Framework_TestCase
     public function testConstruct()
     {
         /* @var $filter \ZfcDatagrid\Filter */
-        $filter = $this->getMock('ZfcDatagrid\Filter');
+        $filter = $this->getMockBuilder('ZfcDatagrid\Filter')
+            ->getMock();
         $filter->setFromColumn($this->column, 'myValue,123');
 
         $filterArray = new FilterArray($filter);
@@ -416,9 +417,13 @@ class FilterTest extends PHPUnit_Framework_TestCase
         ]));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testException()
     {
-        $filter = $this->getMock('ZfcDatagrid\Filter');
+        $filter = $this->getMockBuilder('ZfcDatagrid\Filter')
+            ->getMock();
         $filter->expects($this->any())
             ->method('getColumn')
             ->will($this->returnValue($this->column));
@@ -430,8 +435,6 @@ class FilterTest extends PHPUnit_Framework_TestCase
         $filter->expects($this->any())
             ->method('getOperator')
             ->will($this->returnValue(' () '));
-
-        $this->setExpectedException('InvalidArgumentException');
 
         $filterArray = new FilterArray($filter);
         $filterArray->applyFilter([

--- a/tests/ZfcDatagridTest/DataSource/PhpArrayTest.php
+++ b/tests/ZfcDatagridTest/DataSource/PhpArrayTest.php
@@ -30,13 +30,14 @@ class PhpArrayTest extends DataSourceTestCase
         $this->source = $source;
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testConstruct()
     {
         $source = clone $this->source;
 
         $this->assertEquals($this->data, $source->getData());
-
-        $this->setExpectedException('InvalidArgumentException');
 
         $source = new PhpArray(null);
     }

--- a/tests/ZfcDatagridTest/DataSource/ZendSelect/FilterTest.php
+++ b/tests/ZfcDatagridTest/DataSource/ZendSelect/FilterTest.php
@@ -53,16 +53,20 @@ class FilterTest extends PHPUnit_Framework_TestCase
         $this->column2->setUniqueId('myCol2');
         $this->column2->setSelect('myCol2');
 
-        $this->mockDriver     = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
-        $this->mockConnection = $this->getMock('Zend\Db\Adapter\Driver\ConnectionInterface');
+        $this->mockDriver     = $this->getMockBuilder('Zend\Db\Adapter\Driver\DriverInterface')
+            ->getMock();
+        $this->mockConnection = $this->getMockBuilder('Zend\Db\Adapter\Driver\ConnectionInterface')
+            ->getMock();
         $this->mockDriver->expects($this->any())
             ->method('checkEnvironment')
             ->will($this->returnValue(true));
         $this->mockDriver->expects($this->any())
             ->method('getConnection')
             ->will($this->returnValue($this->mockConnection));
-        $this->mockPlatform  = $this->getMock('Zend\Db\Adapter\Platform\PlatformInterface');
-        $this->mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $this->mockPlatform  = $this->getMockBuilder('Zend\Db\Adapter\Platform\PlatformInterface')
+            ->getMock();
+        $this->mockStatement = $this->getMockBuilder('Zend\Db\Adapter\Driver\StatementInterface')
+            ->getMock();
         $this->mockDriver->expects($this->any())
             ->method('createStatement')
             ->will($this->returnValue($this->mockStatement));
@@ -409,9 +413,13 @@ class FilterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('myValue', $operator->getMaxValue());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testException()
     {
-        $filter = $this->getMock('ZfcDatagrid\Filter');
+        $filter = $this->getMockBuilder('ZfcDatagrid\Filter')
+            ->getMock();
         $filter->expects($this->any())
             ->method('getColumn')
             ->will($this->returnValue($this->column));
@@ -424,7 +432,6 @@ class FilterTest extends PHPUnit_Framework_TestCase
             ->method('getOperator')
             ->will($this->returnValue(' () '));
 
-        $this->setExpectedException('InvalidArgumentException');
         $filterSelect = clone $this->filterSelect;
         $filterSelect->applyFilter($filter);
     }

--- a/tests/ZfcDatagridTest/DataSource/ZendSelectTest.php
+++ b/tests/ZfcDatagridTest/DataSource/ZendSelectTest.php
@@ -46,20 +46,20 @@ class ZendSelectTest extends DataSourceTestCase
     {
         parent::setUp();
 
-        $this->mockDriver     = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
-        $this->mockConnection = $this->getMock('Zend\Db\Adapter\Driver\ConnectionInterface');
+        $this->mockDriver     = $this->getMockBuilder('Zend\Db\Adapter\Driver\DriverInterface')->getMock();
+        $this->mockConnection = $this->getMockBuilder('Zend\Db\Adapter\Driver\ConnectionInterface')->getMock();
         $this->mockDriver->expects($this->any())
             ->method('checkEnvironment')
             ->will($this->returnValue(true));
         $this->mockDriver->expects($this->any())
             ->method('getConnection')
             ->will($this->returnValue($this->mockConnection));
-        $this->mockPlatform = $this->getMock('Zend\Db\Adapter\Platform\PlatformInterface');
+        $this->mockPlatform = $this->getMockBuilder('Zend\Db\Adapter\Platform\PlatformInterface')->getMock();
         $this->mockPlatform->expects($this->any())
             ->method('getIdentifierSeparator')
             ->will($this->returnValue('.'));
 
-        $this->mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $this->mockStatement = $this->getMockBuilder('Zend\Db\Adapter\Driver\StatementInterface')->getMock();
         $this->mockDriver->expects($this->any())
             ->method('createStatement')
             ->will($this->returnValue($this->mockStatement));
@@ -78,31 +78,38 @@ class ZendSelectTest extends DataSourceTestCase
         ]);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage A instance of Zend\Db\SqlSelect is needed to use this dataSource!
+     */
     public function testConstruct()
     {
-        $select = $this->getMock('Zend\Db\Sql\Select');
+        $select = $this->getMockBuilder('Zend\Db\Sql\Select')->getMock();
 
         $source = new ZendSelect($select);
 
         $this->assertInstanceOf('Zend\Db\Sql\Select', $source->getData());
         $this->assertEquals($select, $source->getData());
 
-        $this->setExpectedException('InvalidArgumentException', 'A instance of Zend\Db\SqlSelect is needed to use this dataSource!');
-
         $source = new ZendSelect([]);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Object "Zend\Db\Sql\Sql" is missing, please call setAdapter() first!
+     */
     public function testExecuteException()
     {
-        $select = $this->getMock('Zend\Db\Sql\Select');
+        $select = $this->getMockBuilder('Zend\Db\Sql\Select')->getMock();
 
         $source = new ZendSelect($select);
-
-        $this->setExpectedException('Exception', 'Object "Zend\Db\Sql\Sql" is missing, please call setAdapter() first!');
 
         $source->execute();
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testAdapter()
     {
         $source = clone $this->source;
@@ -113,7 +120,6 @@ class ZendSelectTest extends DataSourceTestCase
         $source->setAdapter($this->adapter);
         $this->assertInstanceOf('Zend\Db\Sql\Sql', $source->getAdapter());
 
-        $this->setExpectedException('InvalidArgumentException');
         $source->setAdapter('something');
     }
 

--- a/tests/ZfcDatagridTest/FilterTest.php
+++ b/tests/ZfcDatagridTest/FilterTest.php
@@ -590,19 +590,23 @@ class FilterTest extends PHPUnit_Framework_TestCase
         ], Filter::BETWEEN));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testIsApplyBetweenInvalidArgumentException()
     {
         $filter = new Filter();
 
-        $this->setExpectedException('\InvalidArgumentException');
         $filter->isApply(123, 100, Filter::BETWEEN);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testIsApplyInvalidArgumentException()
     {
         $filter = new Filter();
 
-        $this->setExpectedException('\InvalidArgumentException');
         $filter->isApply(123, 100, 'UndefinedFilter');
     }
 }

--- a/tests/ZfcDatagridTest/PrepareDataTest.php
+++ b/tests/ZfcDatagridTest/PrepareDataTest.php
@@ -136,7 +136,8 @@ class PrepareDataTest extends PHPUnit_Framework_TestCase
             $this->col1,
         ]);
 
-        $translator = $this->getMock('Zend\I18n\Translator\Translator');
+        $translator = $this->getMockBuilder('Zend\I18n\Translator\Translator')
+            ->getMock();
 
         $prepare->setTranslator($translator);
         $this->assertEquals($translator, $prepare->getTranslator());
@@ -288,7 +289,8 @@ class PrepareDataTest extends PHPUnit_Framework_TestCase
             $this->col3,
         ]);
 
-        $translator = $this->getMock('Zend\I18n\Translator\Translator');
+        $translator = $this->getMockBuilder('Zend\I18n\Translator\Translator')
+            ->getMock();
         $translator->expects($this->any())
             ->method('translate')
             ->will($this->returnCallback(function ($name) {
@@ -339,7 +341,8 @@ class PrepareDataTest extends PHPUnit_Framework_TestCase
             $col3,
         ]);
 
-        $translator = $this->getMock('Zend\I18n\Translator\Translator');
+        $translator = $this->getMockBuilder('Zend\I18n\Translator\Translator')
+            ->getMock();
         $translator->expects($this->any())
             ->method('translate')
             ->will($this->returnCallback(function ($name) {
@@ -383,7 +386,8 @@ class PrepareDataTest extends PHPUnit_Framework_TestCase
     {
         $data = $this->data;
 
-        $mock = $this->getMock('ZfcDatagrid\Column\DataPopulation\Object\Gravatar');
+        $mock = $this->getMockBuilder('ZfcDatagrid\Column\DataPopulation\Object\Gravatar')
+            ->getMock();
         $mock->expects($this->any())
             ->method('toString')
             ->will($this->returnValue('myReturn'));
@@ -392,7 +396,8 @@ class PrepareDataTest extends PHPUnit_Framework_TestCase
         $object->setObject($mock);
         $object->addObjectParameterColumn('email', $this->col1);
 
-        $col = $this->getMock('ZfcDatagrid\Column\ExternalData');
+        $col = $this->getMockBuilder('ZfcDatagrid\Column\ExternalData')
+            ->getMock();
         $col->expects($this->any())
             ->method('getUniqueId')
             ->will($this->returnValue('colPopulation'));

--- a/tests/ZfcDatagridTest/Renderer/AbstractExportTest.php
+++ b/tests/ZfcDatagridTest/Renderer/AbstractExportTest.php
@@ -38,6 +38,10 @@ class AbstractExportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(date('Y-m-d_H-i-s') . '_My_title', $filename);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Currently only "A" paper formats are supported!
+     */
     public function testPaperWidth()
     {
         $exportMock = clone $this->exportMock;
@@ -110,7 +114,6 @@ class AbstractExportTest extends PHPUnit_Framework_TestCase
         ];
         $exportMock->setOptions($options);
 
-        $this->setExpectedException('Exception', 'Currently only "A" paper formats are supported!');
         $width = $method->invoke($exportMock);
     }
 }

--- a/tests/ZfcDatagridTest/Renderer/AbstractRendererTest.php
+++ b/tests/ZfcDatagridTest/Renderer/AbstractRendererTest.php
@@ -62,7 +62,8 @@ class AbstractRendererTest extends PHPUnit_Framework_TestCase
 
         $this->assertNull($renderer->getViewModel());
 
-        $viewModel = $this->getMock('Zend\View\Model\ViewModel');
+        $viewModel = $this->getMockBuilder('Zend\View\Model\ViewModel')
+            ->getMock();
         $renderer->setViewModel($viewModel);
         $this->assertSame($viewModel, $renderer->getViewModel());
     }
@@ -239,9 +240,13 @@ class AbstractRendererTest extends PHPUnit_Framework_TestCase
         /* @var $renderer \ZfcDatagrid\Renderer\AbstractRenderer */
         $renderer = $this->getMockForAbstractClass('ZfcDatagrid\Renderer\AbstractRenderer');
 
-        $request = $this->getMock('Zend\Http\Request', [], [], '', false);
+        $request = $this->getMockBuilder('Zend\Http\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $mvcEvent = $this->getMock('Zend\Mvc\MvcEvent', [], [], '', false);
+        $mvcEvent = $this->getMockBuilder('Zend\Mvc\MvcEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
         $mvcEvent->expects($this->any())
             ->method('getRequest')
             ->will($this->returnValue($request));
@@ -259,7 +264,9 @@ class AbstractRendererTest extends PHPUnit_Framework_TestCase
         /* @var $renderer \ZfcDatagrid\Renderer\AbstractRenderer */
         $renderer = $this->getMockForAbstractClass('ZfcDatagrid\Renderer\AbstractRenderer');
 
-        $translator = $this->getMock('Zend\I18n\Translator\Translator', [], [], '', false);
+        $translator = $this->getMockBuilder('Zend\I18n\Translator\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->assertNull($renderer->getTranslator());
         $renderer->setTranslator($translator);
@@ -272,7 +279,10 @@ class AbstractRendererTest extends PHPUnit_Framework_TestCase
         $renderer = $this->getMockForAbstractClass('ZfcDatagrid\Renderer\AbstractRenderer');
         $this->assertEquals('foobar', $renderer->translate('foobar'));
 
-        $translator = $this->getMock('Zend\I18n\Translator\Translator', ['translate'], [], '', false);
+        $translator = $this->getMockBuilder('Zend\I18n\Translator\Translator')
+            ->disableOriginalConstructor()
+            ->setMethods(['translate'])
+            ->getMock();
         $translator->expects($this->any())
             ->method('translate')
             ->willReturn('barfoo');
@@ -341,12 +351,16 @@ class AbstractRendererTest extends PHPUnit_Framework_TestCase
 
     public function testGetFiltersDefault()
     {
-        $request = $this->getMock('Zend\Http\PhpEnvironment\Request', [], [], '', false);
+        $request = $this->getMockBuilder('Zend\Http\PhpEnvironment\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
         $request->expects($this->any())
             ->method('isPost')
             ->will($this->returnValue(false));
 
-        $mvcEvent = $this->getMock('Zend\Mvc\MvcEvent', [], [], '', false);
+        $mvcEvent = $this->getMockBuilder('Zend\Mvc\MvcEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
         $mvcEvent->expects($this->any())
             ->method('getRequest')
             ->will($this->returnValue($request));

--- a/tests/ZfcDatagridTest/Renderer/BootstrapTable/RendererTest.php
+++ b/tests/ZfcDatagridTest/Renderer/BootstrapTable/RendererTest.php
@@ -31,11 +31,19 @@ class RendererTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($renderer->isHtml());
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Request must be an instance of Zend\Http\PhpEnvironment\Request for HTML rendering
+     */
     public function testGetRequestException()
     {
-        $request = $this->getMock('Zend\Console\Request', [], [], '', false);
+        $request = $this->getMockBuilder('Zend\Console\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $mvcEvent = $this->getMock('Zend\Mvc\MvcEvent', [], [], '', false);
+        $mvcEvent = $this->getMockBuilder('Zend\Mvc\MvcEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
         $mvcEvent->expects($this->any())
         ->method('getRequest')
         ->will($this->returnValue($request));
@@ -43,15 +51,19 @@ class RendererTest extends PHPUnit_Framework_TestCase
         $renderer = new BootstrapTable\Renderer();
         $renderer->setMvcEvent($mvcEvent);
 
-        $this->setExpectedException('Exception', 'Request must be an instance of Zend\Http\PhpEnvironment\Request for HTML rendering');
         $renderer->getRequest();
     }
 
     public function testGetRequest()
     {
-        $request = $this->getMock('Zend\Http\PhpEnvironment\Request', [], [], '', false);
+        $request = $this->getMockBuilder('Zend\Http\PhpEnvironment\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $mvcEvent = $this->getMock('Zend\Mvc\MvcEvent', [], [], '', false);
+        $mvcEvent = $this->getMockBuilder('Zend\Mvc\MvcEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $mvcEvent->expects($this->any())
         ->method('getRequest')
         ->will($this->returnValue($request));

--- a/tests/ZfcDatagridTest/Renderer/BootstrapTable/View/Helper/TableRowTest.php
+++ b/tests/ZfcDatagridTest/Renderer/BootstrapTable/View/Helper/TableRowTest.php
@@ -36,7 +36,8 @@ class TableRowTest extends PHPUnit_Framework_TestCase
 
         $this->myCol = $myCol;
 
-        $this->serviceLocator = $this->getMock('Zend\ServiceManager\ServiceManager');
+        $this->serviceLocator = $this->getMockBuilder('Zend\ServiceManager\ServiceManager')
+            ->getMock();
     }
 
     public function testCanExecute()
@@ -101,6 +102,9 @@ class TableRowTest extends PHPUnit_Framework_TestCase
         $this->assertContains('<pre>First value</pre>', $html);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testStyle()
     {
         $helper = new TableRow();
@@ -166,7 +170,6 @@ class TableRowTest extends PHPUnit_Framework_TestCase
             $myCol,
         ];
 
-        $this->setExpectedException('InvalidArgumentException');
         $html = $helper($this->rowWithId, $cols);
     }
 

--- a/tests/ZfcDatagridTest/Renderer/JqGrid/RendererTest.php
+++ b/tests/ZfcDatagridTest/Renderer/JqGrid/RendererTest.php
@@ -44,11 +44,19 @@ class RendererTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($renderer->isHtml());
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Request must be an instance of Zend\Http\PhpEnvironment\Request for HTML rendering
+     */
     public function testGetRequestException()
     {
-        $request = $this->getMock('Zend\Console\Request', [], [], '', false);
+        $request = $this->getMockBuilder('Zend\Console\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $mvcEvent = $this->getMock('Zend\Mvc\MvcEvent', [], [], '', false);
+        $mvcEvent = $this->getMockBuilder('Zend\Mvc\MvcEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
         $mvcEvent->expects($this->any())
             ->method('getRequest')
             ->will($this->returnValue($request));
@@ -56,15 +64,18 @@ class RendererTest extends PHPUnit_Framework_TestCase
         $renderer = new JqGrid\Renderer();
         $renderer->setMvcEvent($mvcEvent);
 
-        $this->setExpectedException('Exception', 'Request must be an instance of Zend\Http\PhpEnvironment\Request for HTML rendering');
         $renderer->getRequest();
     }
 
     public function testGetRequest()
     {
-        $request = $this->getMock('Zend\Http\PhpEnvironment\Request', [], [], '', false);
+        $request = $this->getMockBuilder('Zend\Http\PhpEnvironment\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $mvcEvent = $this->getMock('Zend\Mvc\MvcEvent', [], [], '', false);
+        $mvcEvent = $this->getMockBuilder('Zend\Mvc\MvcEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
         $mvcEvent->expects($this->any())
             ->method('getRequest')
             ->will($this->returnValue($request));

--- a/tests/ZfcDatagridTest/Renderer/JqGrid/View/Helper/ColumnsTest.php
+++ b/tests/ZfcDatagridTest/Renderer/JqGrid/View/Helper/ColumnsTest.php
@@ -23,7 +23,9 @@ class ColumnsTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->sm = $this->getMock('Zend\View\HelperPluginManager', [], [], '', false);
+        $this->sm = $this->getMockBuilder('Zend\View\HelperPluginManager')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $myCol = $this->getMockForAbstractClass('ZfcDatagrid\Column\AbstractColumn');
         $myCol->setUniqueId('myCol');
@@ -109,6 +111,10 @@ class ColumnsTest extends PHPUnit_Framework_TestCase
         $this->assertStringEndsWith('search: true,searchoptions: {"clearSearch":false}}]', $result);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessageRegExp  /Not defined style: \"[a-zA-Z0-9_]+\"/
+     */
     public function testStyleException()
     {
         $styleMock = $this->getMockForAbstractClass('ZfcDatagrid\Column\Style\AbstractStyle');
@@ -120,7 +126,6 @@ class ColumnsTest extends PHPUnit_Framework_TestCase
             $col1,
         ];
 
-        $this->setExpectedException('Exception', 'Not defined style: "' . get_class($styleMock) . '"');
         $result = $helper($cols);
 
         $this->assertStringStartsWith('[{name:', $result);
@@ -183,6 +188,10 @@ class ColumnsTest extends PHPUnit_Framework_TestCase
         $this->assertStringEndsWith('if (rowObject.myCol != \'123\') {cellvalue = \'<span style="font-weight: bold;">\' + cellvalue + \'</span>\';} return cellvalue; },searchoptions: {"clearSearch":false}}]', $result);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Currently not supported filter operation: "=(%s)"
+     */
     public function testStyleByValueNotSupported()
     {
         $helper = new Helper\Columns();
@@ -197,14 +206,15 @@ class ColumnsTest extends PHPUnit_Framework_TestCase
             $col1,
         ];
 
-        $this->setExpectedException('Exception', 'Currently not supported filter operation: "' . Filter::IN . '"');
         $result = $helper($cols);
     }
 
     public function testTranslate()
     {
         /** @var \PHPUnit_Framework_MockObject_MockObject|\Zend\ServiceManager\ServiceManager $sm */
-        $sm = $this->getMock('Zend\ServiceManager\ServiceManager', null);
+        $sm = $this->getMockBuilder('Zend\ServiceManager\ServiceManager')
+            ->setMethods(null)
+            ->getMock();
 
         $helper = new Helper\Columns();
 

--- a/tests/ZfcDatagridTest/Renderer/ZendTable/RendererTest.php
+++ b/tests/ZfcDatagridTest/Renderer/ZendTable/RendererTest.php
@@ -46,8 +46,13 @@ class RendererTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->requestMock  = $this->getMock('Zend\Console\Request', [], [], '', false);
-        $this->mvcEventMock = $this->getMock('Zend\Mvc\MvcEvent', [], [], '', false);
+        $this->requestMock  = $this->getMockBuilder('Zend\Console\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mvcEventMock = $this->getMockBuilder('Zend\Mvc\MvcEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->colMock = $this->getMockForAbstractClass('ZfcDatagrid\Column\AbstractColumn');
     }
@@ -73,9 +78,15 @@ class RendererTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($renderer->isHtml());
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Request must be an instance of Zend\Console\Request for console rendering
+     */
     public function testGetRequestException()
     {
-        $request = $this->getMock('Zend\Http\PhpEnvironment\Request', [], [], '', false);
+        $request = $this->getMockBuilder('Zend\Http\PhpEnvironment\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $mvcEvent = clone $this->mvcEventMock;
         $mvcEvent->expects($this->any())
@@ -85,7 +96,6 @@ class RendererTest extends PHPUnit_Framework_TestCase
         $renderer = new ZendTable\Renderer();
         $renderer->setMvcEvent($mvcEvent);
 
-        $this->setExpectedException('Exception', 'Request must be an instance of Zend\Console\Request for console rendering');
         $renderer->getRequest();
     }
 
@@ -307,6 +317,10 @@ class RendererTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(99, $renderer->getItemsPerPage());
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage No columns to display available
+     */
     public function testGetColumnsToDisplay()
     {
         $reflection = new ReflectionClass('ZfcDatagrid\Renderer\ZendTable\Renderer');
@@ -319,7 +333,9 @@ class RendererTest extends PHPUnit_Framework_TestCase
         $col2 = $this->getMockForAbstractClass('ZfcDatagrid\Column\AbstractColumn');
         $col2->setWidth(20);
 
-        $col3 = $this->getMock('ZfcDatagrid\Column\Action');
+        $col3 = $this->getMockBuilder('ZfcDatagrid\Column\Action')
+            ->disableOriginalConstructor()
+            ->getMock();
         $col3->setWidth(20);
 
         $renderer = new ZendTable\Renderer();
@@ -344,7 +360,6 @@ class RendererTest extends PHPUnit_Framework_TestCase
             $col2,
         ], $result);
 
-        $this->setExpectedException('Exception', 'No columns to display available');
         $renderer = new ZendTable\Renderer();
         $method->invoke($renderer);
     }

--- a/tests/ZfcDatagridTest/Service/DatagridFactoryTest.php
+++ b/tests/ZfcDatagridTest/Service/DatagridFactoryTest.php
@@ -37,9 +37,12 @@ class DatagridFactoryTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $mvcEventMock = $this->getMock('Zend\Mvc\MvcEvent');
+        $mvcEventMock = $this->getMockBuilder('Zend\Mvc\MvcEvent')
+            ->getMock();
 
-        $this->applicationMock = $this->getMock('Zend\Mvc\Application', [], [], '', false);
+        $this->applicationMock = $this->getMockBuilder('Zend\Mvc\Application')
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->applicationMock->expects($this->any())
             ->method('getMvcEvent')
             ->will($this->returnValue($mvcEventMock));
@@ -48,10 +51,12 @@ class DatagridFactoryTest extends PHPUnit_Framework_TestCase
             ->getMock();
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Config key "ZfcDatagrid" is missing
+     */
     public function testCreateServiceException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Config key "ZfcDatagrid" is missing');
-
         $sm = new ServiceManager();
         $sm->setService('config', []);
 
@@ -74,7 +79,9 @@ class DatagridFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testCanCreateServiceWithTranslator()
     {
-        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator', [], [], '', false);
+        $translatorMock = $this->getMockBuilder('Zend\I18n\Translator\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $sm = new ServiceManager();
         $sm->setService('config', $this->config);
@@ -91,7 +98,9 @@ class DatagridFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testCanCreateServiceWithMvcTranslator()
     {
-        $mvcTranslatorMock = $this->getMock('Zend\Mvc\I18n\Translator', [], [], '', false);
+        $mvcTranslatorMock = $this->getMockBuilder('Zend\Mvc\I18n\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $sm = new ServiceManager();
         $sm->setService('config', $this->config);


### PR DESCRIPTION
- unittests update, removed deprecated method `getMock`
- also removed deprecated method setExpectedException
- run cs fix
- update composer for cs-fix