### PR TITLE
Provide a way to set a route instead of the absolute link in a select or action column

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Add `ZfcDatagrid` to your `config/application.config.php`
 
 Finally create the folder: `data/ZfcDatagrid`
 
+You can cotinue 
+
 ### Test if it works
 
 > NOTE: This needs the additional module `ZfcDatagridExamples` https://github.com/ThaDafinser/ZfcDatagridExamples
@@ -77,7 +79,14 @@ php index.php datagrid person --page 2
 php index.php datagrid person --sortBys=age
 php index.php datagrid person --sortBys=age,givenName --sortDirs=ASC,DESC
 ```
+## Continue with your own datagrid
+
+Please read [Documentation](https://github.com/ThaDafinser/ZfcDatagrid/blob/master/docs/)
+
+You can also use the [zfc-data-grid-plugin](https://github.com/agerecompany/zfc-data-grid-plugin) to create columns with an array configuration, instead of objects!
+
 
 ## Screenshots
 ![ScreenShot](https://raw.github.com/ThaDafinser/ZfcDatagrid/master/docs/screenshots/ZfcDatagrid_bootstrap.jpg)
 ![ScreenShot](https://raw.github.com/ThaDafinser/ZfcDatagrid/master/docs/screenshots/ZfcDatagrid_console.jpg)
+

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,10 @@
         "zendframework/zend-db": "~2.5",
         "zendframework/zend-i18n": "~2.5",
         "zendframework/zend-text": "~2.5",
-        "zendframework/zend-json": "~2.5"
+        "zendframework/zend-json": "~2.5",
+
+        "phpoffice/phpexcel": "^1.8",
+        "tecnickcom/tcpdf": "^6.2"
     },
     
     "suggest" : {

--- a/composer.json
+++ b/composer.json
@@ -62,11 +62,19 @@
         "zendframework/zend-json": "to support date ranges"
     },
 
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.4-dev",
+            "dev-develop": "2.0-dev"
+        }
+    },
+
     "autoload": {
         "psr-4": {
             "ZfcDatagrid\\": "src/ZfcDatagrid"
         }
     },
+
     "autoload-dev": {
         "psr-4": {
             "ZfcDatagridTest\\": "tests/ZfcDatagridTest"

--- a/docs/03. Columns.md
+++ b/docs/03. Columns.md
@@ -44,6 +44,7 @@ $col = new Column\Select('columnDataKey');
 $col->setLabel('Display Name');
 $grid->addColumn($col);
 ```
+You can also use the [zfc-data-grid-plugin](https://github.com/agerecompany/zfc-data-grid-plugin) to create columns with an array configuration, instead of objects!
 
 ## Column Types
 The column type is the basic object that is created and added to the ZfcDatagrid to contruct the grid table, you can choose between `Action`, `ExternalData` and `Select` column types.

--- a/src/ZfcDatagrid/Column/Action/AbstractAction.php
+++ b/src/ZfcDatagrid/Column/Action/AbstractAction.php
@@ -26,6 +26,16 @@ abstract class AbstractAction
     protected $showOnValueOperator = 'OR';
 
     /**
+     * @var string
+     */
+    protected $route;
+
+    /**
+     * @var array
+     */
+    protected $routeParams = array();
+
+    /**
      * @var array
      */
     protected $showOnValues = [];
@@ -51,6 +61,38 @@ abstract class AbstractAction
     public function getLink()
     {
         return $this->getAttribute('href');
+    }
+
+    /**
+     * @param string $route
+     */
+    public function setRoute($route)
+    {
+        $this->route = $route;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRoute()
+    {
+        return $this->route;
+    }
+
+    /**
+     * @param array $params
+     */
+    public function setRouteParams(array $params)
+    {
+        $this->routeParams = $params;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRouteParams()
+    {
+        return $this->routeParams;
     }
 
     /**

--- a/src/ZfcDatagrid/Column/Formatter/HtmlTag.php
+++ b/src/ZfcDatagrid/Column/Formatter/HtmlTag.php
@@ -2,9 +2,10 @@
 
 namespace ZfcDatagrid\Column\Formatter;
 
+use Zend\Router\RouteStackInterface;
 use ZfcDatagrid\Column\AbstractColumn;
 
-class HtmlTag extends AbstractFormatter
+class HtmlTag extends AbstractFormatter implements RouterInterface
 {
     const ROW_ID_PLACEHOLDER = ':rowId:';
 
@@ -30,6 +31,39 @@ class HtmlTag extends AbstractFormatter
      * @var array
      */
     protected $attributes = [];
+
+    /**
+     * @var string
+     */
+    protected $route;
+
+    /**
+     * @var array
+     */
+    protected $routeParams = array();
+
+    /**
+     * @var RouteStackInterface
+     */
+    public $router;
+
+    /**
+     * @param \Zend\Router\RouteStackInterface $router
+     *
+     * @return void
+     */
+    public function setRouter(RouteStackInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @return \Zend\Router\RouteStackInterface
+     */
+    public function getRouter()
+    {
+        return $this->router;
+    }
 
     /**
      * @param $name
@@ -115,6 +149,38 @@ class HtmlTag extends AbstractFormatter
     }
 
     /**
+     * @param string $route
+     */
+    public function setRoute($route)
+    {
+        $this->route = $route;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRoute()
+    {
+        return $this->route;
+    }
+
+    /**
+     * @param array $params
+     */
+    public function setRouteParams(array $params)
+    {
+        $this->routeParams = $params;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRouteParams()
+    {
+        return $this->routeParams;
+    }
+
+    /**
      * Get the column row value placeholder
      * $fmt->setLink('/myLink/something/'.$fmt->getColumnValuePlaceholder($myCol));.
      *
@@ -169,6 +235,14 @@ class HtmlTag extends AbstractFormatter
     protected function getAttributesString(AbstractColumn $col)
     {
         $attributes = [];
+
+        if ($this->getRoute() && $this->getRouter() instanceof RouteStackInterface) {
+            $this->setLink( $this->getRouter()->assemble(
+                $this->getRouteParams(),
+                array('name' => $this->getRoute())
+            ));
+        }
+
         foreach ($this->getAttributes() as $attrKey => $attrValue) {
             if ('href' === $attrKey) {
                 $attrValue = $this->getLinkReplaced($col);

--- a/src/ZfcDatagrid/Column/Formatter/RouterInterface.php
+++ b/src/ZfcDatagrid/Column/Formatter/RouterInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ZfcDatagrid\Column\Formatter;
+
+use Zend\Router\RouteStackInterface;
+
+/**
+ * Interface RouterInterface
+ * @package ZfcDatagrid\Column\Formatter
+ */
+interface RouterInterface
+{
+    /**
+     * @param \Zend\Router\RouteStackInterface $router
+     *
+     * @return void
+     */
+    public function setRouter(RouteStackInterface $router);
+
+    /**
+     * @return \Zend\Router\RouteStackInterface
+     */
+    public function getRouter();
+}

--- a/src/ZfcDatagrid/Datagrid.php
+++ b/src/ZfcDatagrid/Datagrid.php
@@ -425,7 +425,7 @@ class Datagrid
      */
     public function hasRouter()
     {
-        return !is_null($this->translator);
+        return !is_null($this->router);
     }
 
     /**

--- a/src/ZfcDatagrid/Datagrid.php
+++ b/src/ZfcDatagrid/Datagrid.php
@@ -13,6 +13,7 @@ use Zend\Http\PhpEnvironment\Request as HttpRequest;
 use Zend\I18n\Translator\Translator;
 use Zend\Mvc\MvcEvent;
 use Zend\Paginator\Paginator;
+use Zend\Router\RouteStackInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Session\Container as SessionContainer;
 use Zend\Stdlib\ResponseInterface;
@@ -78,6 +79,11 @@ class Datagrid
      * @var Translator
      */
     protected $translator;
+
+    /**
+     * @var RouteStackInterface
+     */
+    protected $router;
 
     /**
      * @var string
@@ -396,6 +402,30 @@ class Datagrid
         }
 
         return false;
+    }
+
+    /**
+     * @param \Zend\Router\RouteStackInterface $router
+     */
+    public function setRouter( RouteStackInterface $router )
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @return RouteStackInterface
+     */
+    public function getRouter()
+    {
+        return $this->router;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasRouter()
+    {
+        return !is_null($this->translator);
     }
 
     /**
@@ -978,6 +1008,10 @@ class Datagrid
          * Step 3) Format the data - Translate - Replace - Date / time / datetime - Numbers - ...
          */
         $prepareData = new PrepareData($data, $this->getColumns());
+        if ($this->getRouter() instanceof RouteStackInterface) {
+            $prepareData->setRouter($this->getRouter());
+        }
+
         $prepareData->setRendererName($this->getRendererName());
         if ($this->hasTranslator()) {
             $prepareData->setTranslator($this->getTranslator());

--- a/src/ZfcDatagrid/PrepareData.php
+++ b/src/ZfcDatagrid/PrepareData.php
@@ -3,6 +3,7 @@
 namespace ZfcDatagrid;
 
 use Zend\I18n\Translator\Translator;
+use Zend\Router\RouteStackInterface;
 
 class PrepareData
 {
@@ -27,6 +28,11 @@ class PrepareData
      * @var Translator
      */
     private $translator;
+
+    /**
+     * @var \Zend\Router\RouteStackInterface
+     */
+    private $router;
 
     /**
      * @param array $data
@@ -114,6 +120,22 @@ class PrepareData
     public function getTranslator()
     {
         return $this->translator;
+    }
+
+    /**
+     * @param \Zend\Router\RouteStackInterface $router
+     */
+    public function setRouter(RouteStackInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @return \Zend\Router\RouteStackInterface
+     */
+    public function getRouter()
+    {
+        return $this->router;
     }
 
     /**
@@ -225,6 +247,12 @@ class PrepareData
                  */
                 if ($col->hasFormatters() === true) {
                     foreach ($col->getFormatters() as $formatter) {
+                        if ($formatter instanceof Column\Formatter\RouterInterface
+                            && $this->getRouter() instanceof RouteStackInterface
+                        ) {
+                            /** @var Column\Formatter\RouterInterface */
+                            $formatter->setRouter($this->getrouter());
+                        }
                         $formatter->setRowData($row);
                         $formatter->setRendererName($this->getRendererName());
 

--- a/src/ZfcDatagrid/PrepareData.php
+++ b/src/ZfcDatagrid/PrepareData.php
@@ -251,7 +251,7 @@ class PrepareData
                             && $this->getRouter() instanceof RouteStackInterface
                         ) {
                             /** @var Column\Formatter\RouterInterface */
-                            $formatter->setRouter($this->getrouter());
+                            $formatter->setRouter($this->getRouter());
                         }
                         $formatter->setRowData($row);
                         $formatter->setRendererName($this->getRendererName());

--- a/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
+++ b/src/ZfcDatagrid/Renderer/BootstrapTable/View/Helper/TableRow.php
@@ -172,6 +172,11 @@ class TableRow extends AbstractHelper
                     /* @var $action Column\Action\AbstractAction */
                     if ($action->isDisplayed($row) === true) {
                         $action->setTitle($this->translate($action->getTitle()));
+
+                        if ($action->getRoute()) {
+                            $action->setLink($this->view->url($action->getRoute(), $action->getRouteParams()));
+                        }
+
                         $actions[] = $action->toHtml($row);
                     }
                 }

--- a/src/ZfcDatagrid/Renderer/TCPDF/Renderer.php
+++ b/src/ZfcDatagrid/Renderer/TCPDF/Renderer.php
@@ -442,7 +442,7 @@ class Renderer extends AbstractExport
         $background = $style['background-color'];
 
         $pdf = $this->getPdf();
-        $pdf->setFont($font, '', $size);
+        $pdf->SetFont($font, '', $size);
         $pdf->SetTextColor($color[0], $color[1], $color[2]);
         $pdf->SetFillColor($background[0], $background[1], $background[2]);
         // "BOLD" fake
@@ -460,7 +460,7 @@ class Renderer extends AbstractExport
         $background = $style['background-color'];
 
         $pdf = $this->getPdf();
-        $pdf->setFont($font, '', $size);
+        $pdf->SetFont($font, '', $size);
         $pdf->SetTextColor($color[0], $color[1], $color[2]);
         $pdf->SetFillColor($background[0], $background[1], $background[2]);
         $pdf->setTextRenderingMode();
@@ -480,7 +480,7 @@ class Renderer extends AbstractExport
         $size = $style['size'];
 
         $pdf = $this->getPdf();
-        $pdf->setFont($font.'I', '', $size);
+        $pdf->SetFont($font.'I', '', $size);
     }
 
     /**

--- a/tests/ZfcDatagridTest/Column/Action/AbstractActionTest.php
+++ b/tests/ZfcDatagridTest/Column/Action/AbstractActionTest.php
@@ -58,6 +58,25 @@ class AbstractActionTest extends PHPUnit_Framework_TestCase
         ]));
     }
 
+    public function testRoute()
+    {
+        /* @var $action \ZfcDatagrid\Column\Action\AbstractAction */
+        $action = $this->getMockForAbstractClass(\ZfcDatagrid\Column\Action\AbstractAction::class);
+
+        $action->setRoute('my_route');
+        $this->assertEquals('my_route', $action->getRoute());
+
+        $action->setRouteParams(array(
+            'id'   => 1,
+            'foo'  => 'bar',
+        ));
+
+        $this->assertEquals(array(
+            'id'   => 1,
+            'foo'  => 'bar',
+        ), $action->getRouteParams());
+    }
+
     public function testToHtml()
     {
         /* @var $action \ZfcDatagrid\Column\Action\AbstractAction */

--- a/tests/ZfcDatagridTest/Column/Formatter/LinkTest.php
+++ b/tests/ZfcDatagridTest/Column/Formatter/LinkTest.php
@@ -2,7 +2,11 @@
 namespace ZfcDatagridTest\Column\Formatter;
 
 use PHPUnit_Framework_TestCase;
+use Zend\Router\Http\HttpRouterFactory;
+use Zend\Router\Http\Segment;
+use Zend\Router\RoutePluginManagerFactory;
 use ZfcDatagrid\Column\Formatter;
+use ZfcDatagridTest\Util\ServiceManagerFactory;
 
 /**
  * @group Column
@@ -18,6 +22,53 @@ class LinkTest extends PHPUnit_Framework_TestCase
             'jqGrid',
             'bootstrapTable',
         ], $formatter->getValidRendererNames());
+    }
+
+    public function getRouter()
+    {
+        $config = array(
+            'router' => array(
+                'routes' => array(
+                    'myTestRoute' => array(
+                        'type'    => Segment::class,
+                        'options' => array(
+                            'route'    => '/foo[/:bar]',
+                            'defaults' => array(
+                                'controller' => 'MyController',
+                                'action'     => 'index',
+                                'bar'        => 'baz',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        // Setup service manager, we need that for the route
+        ServiceManagerFactory::setConfig( $config );
+        $serviceLocator = ServiceManagerFactory::getServiceManager();
+
+        $routePluginManager = new RoutePluginManagerFactory();
+        $serviceLocator->setService('RoutePluginManager', $routePluginManager->createService($serviceLocator));
+        $routerFactory = new HttpRouterFactory();
+
+        return $routerFactory->createService($serviceLocator);
+    }
+
+    public function testRouteToLinkConversion()
+    {
+        // Setup a mock column
+        $col = $this->getMockForAbstractClass(\ZfcDatagrid\Column\AbstractColumn::class);
+        $col->setUniqueId('myCol');
+
+        // Setup the formatter
+        $formatter = new Formatter\Link();
+        $formatter->setRouter($this->getRouter());
+        $formatter->setRoute('myTestRoute');
+        $formatter->setRouteParams(array('bar' => 'xyz'));
+        $formatter->setRowData(array('myCol' => 'Test'));
+
+        $this->assertEquals('<a href="/foo/xyz">Test</a>', $formatter->getFormattedValue($col));
     }
 
     public function testGetFormattedValue()

--- a/tests/ZfcDatagridTest/DatagridTest.php
+++ b/tests/ZfcDatagridTest/DatagridTest.php
@@ -5,10 +5,14 @@ use PHPUnit_Framework_TestCase;
 use Zend\Http\PhpEnvironment\Request;
 use Zend\I18n\Translator\Translator;
 use Zend\Mvc\MvcEvent;
+use Zend\Router\Http\HttpRouterFactory;
+use Zend\Router\Http\Segment;
+use Zend\Router\RoutePluginManagerFactory;
 use Zend\Session\Container;
 use ZfcDatagrid\Column;
 use ZfcDatagrid\Datagrid;
 use ZfcDatagrid\DataSource\PhpArray;
+use ZfcDatagridTest\Util\ServiceManagerFactory;
 
 /**
  * @group Datagrid
@@ -606,5 +610,44 @@ class DatagridTest extends PHPUnit_Framework_TestCase
         $customView = $this->getMockBuilder(\Zend\View\Model\ViewModel::class)->getMock();
 
         $grid->setViewModel($customView);
+    }
+
+    public function getRouter()
+    {
+        $config = array(
+            'router' => array(
+                'routes' => array(
+                    'myTestRoute' => array(
+                        'type'    => Segment::class,
+                        'options' => array(
+                            'route'    => '/foo[/:bar]',
+                            'defaults' => array(
+                                'controller' => 'MyController',
+                                'action'     => 'index',
+                                'bar'        => 'baz',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        // Setup service manager, we need that for the route
+        ServiceManagerFactory::setConfig( $config );
+        $serviceLocator = ServiceManagerFactory::getServiceManager();
+
+        $routePluginManager = new RoutePluginManagerFactory();
+        $serviceLocator->setService('RoutePluginManager', $routePluginManager->createService($serviceLocator));
+        $routerFactory = new HttpRouterFactory();
+
+        return $routerFactory->createService($serviceLocator);
+    }
+
+    public function testGetAndSetRouter()
+    {
+        $router = $this->getRouter();
+        $grid   = new Datagrid();
+        $grid->setRouter($router);
+        $this->assertSame($router, $grid->getRouter());
     }
 }

--- a/tests/ZfcDatagridTest/PrepareDataTest.php
+++ b/tests/ZfcDatagridTest/PrepareDataTest.php
@@ -2,12 +2,16 @@
 namespace ZfcDatagridTest;
 
 use PHPUnit_Framework_TestCase;
+use Zend\Router\Http\HttpRouterFactory;
+use Zend\Router\Http\Segment;
+use Zend\Router\RoutePluginManagerFactory;
 use ZfcDatagrid\Column\DataPopulation\Object;
 use ZfcDatagrid\Column\Type;
 use ZfcDatagrid\PrepareData;
+use ZfcDatagridTest\Util\ServiceManagerFactory;
 
 /**
- * @covers ZfcDatagrid\PrepareData
+ * @covers \ZfcDatagrid\PrepareData
  */
 class PrepareDataTest extends PHPUnit_Framework_TestCase
 {
@@ -448,6 +452,70 @@ class PrepareDataTest extends PHPUnit_Framework_TestCase
         $data[0]['col1'] = '<a href="test">test</a>';
         $data[1]['col1'] = '<a href="test">test</a>';
         $data[2]['col1'] = '<a href="test">test</a>';
+
+        $data[1]['col2'] = '';
+
+        $this->assertEquals($data, $prepare->getData());
+    }
+
+    public function getRouter()
+    {
+        $config = array(
+            'router' => array(
+                'routes' => array(
+                    'myTestRoute' => array(
+                        'type'    => Segment::class,
+                        'options' => array(
+                            'route'    => '/foo[/:bar]',
+                            'defaults' => array(
+                                'controller' => 'MyController',
+                                'action'     => 'index',
+                                'bar'        => 'baz',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        // Setup service manager, we need that for the route
+        ServiceManagerFactory::setConfig( $config );
+        $serviceLocator = ServiceManagerFactory::getServiceManager();
+
+        $routePluginManager = new RoutePluginManagerFactory();
+        $serviceLocator->setService('RoutePluginManager', $routePluginManager->createService($serviceLocator));
+        $routerFactory = new HttpRouterFactory();
+
+        return $routerFactory->createService($serviceLocator);
+    }
+
+    public function testRouterDependency()
+    {
+        $data = $this->data;
+
+        $col1 = clone $this->col1;
+        $formatter = new \ZfcDatagrid\Column\Formatter\Link();
+        $formatter->setRoute('myTestRoute');
+        $formatter->setRouteParams(array('bar' => 'xyz'));
+        $col1->addFormatter($formatter);
+        $prepare = new PrepareData($data, [
+            $this->colId,
+            $col1,
+            $this->col2,
+        ]);
+        $prepare->setRendererName('bootstrapTable');
+
+        $router = $this->getRouter();
+        $prepare->setRouter($router);
+        $this->assertSame($router, $prepare->getRouter());
+
+        $data[0]['idConcated'] = '1';
+        $data[1]['idConcated'] = '2';
+        $data[2]['idConcated'] = '3';
+
+        $data[0]['col1'] = '<a href="/foo/xyz">test</a>';
+        $data[1]['col1'] = '<a href="/foo/xyz">test</a>';
+        $data[2]['col1'] = '<a href="/foo/xyz">test</a>';
 
         $data[1]['col2'] = '';
 

--- a/tests/ZfcDatagridTest/Util/ServiceManagerFactory.php
+++ b/tests/ZfcDatagridTest/Util/ServiceManagerFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ZfcDatagridTest\Util;
+
+use Zend\Mvc\Service\ServiceListenerFactory;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * Class ServiceManagerFactory
+ * @package ZfcDatagridTest\Util
+ */
+class ServiceManagerFactory
+{
+    /**
+     * @var array
+     */
+    protected static $config = array();
+
+    /**
+     * @param array $config
+     */
+    public static function setConfig(array $config)
+    {
+        static::$config = $config;
+    }
+
+    /**
+     * @return \Zend\ServiceManager\ServiceManager
+     */
+    public static function getServiceManager()
+    {
+        $serviceManager = new ServiceManager(
+            isset(static::$config['service_manager']) ? static::$config['service_manager'] : array()
+        );
+        $serviceManager->setService('Applicationconfig', static::$config);
+        $serviceManager->setFactory('ServiceListener', ServiceListenerFactory::class);
+
+        $serviceManager->setService( 'config', self::$config );
+
+        return $serviceManager;
+    }
+}

--- a/view/zfc-datagrid/renderer/bootstrapTable/footer.phtml
+++ b/view/zfc-datagrid/renderer/bootstrapTable/footer.phtml
@@ -23,11 +23,11 @@ $paginator = $this->paginator;
     <div class="span4 col-md-4 text-center">
         <input type="hidden" name="<?php echo $this->parameterNames['currentPage']; ?>" value="<?php echo $this->paginator->getPages()->current; ?>" />
         <?php 
-        echo $this->paginationcontrol($this->paginator, 'Elastic', 'zfc-datagrid/renderer/bootstrapTable/paginator', array(
+        echo $this->paginationcontrol($this->paginator, 'Elastic', 'zfc-datagrid/renderer/bootstrapTable/paginator', [
             'activeParameters' => $this->activeParameters, 
             'parameterNames' => $this->parameterNames,
             'gridId' => $this->gridId
-        ));
+        ]);
         ?>
     </div>
     <!-- Info -->

--- a/view/zfc-datagrid/renderer/bootstrapTable/paginator.phtml
+++ b/view/zfc-datagrid/renderer/bootstrapTable/paginator.phtml
@@ -11,13 +11,13 @@ $paginatorOnclick.= 'document.forms[\'form_'.$this->gridId.'\'].submit(); return
         <?php if($this->current > 1):?>
             <li><a href="<?php echo 
                     $this->url(null, 
-                        array(),
-                        array(
-                            'query' => array_merge($this->activeParameters, array(
+                        [],
+                        [
+                            'query' => array_merge($this->activeParameters, [
                                     $this->parameterNames['currentPage'] => 1
-                                )
+                                ]
                             )
-                        ),
+                        ],
                         true
                     );?>
                 "  onclick="<?php echo sprintf($paginatorOnclick, 1);?>">
@@ -34,13 +34,13 @@ $paginatorOnclick.= 'document.forms[\'form_'.$this->gridId.'\'].submit(); return
         <?php if($this->current > 1): ?>
             <li><a href="<?php echo 
                     $this->url(null, 
-                        array(),
-                        array(
-                            'query' => array_merge($this->activeParameters, array(
+                        [],
+                        [
+                            'query' => array_merge($this->activeParameters, [
                                     $this->parameterNames['currentPage'] => $this->current - 1
-                                )
+                                ]
                             )
-                        ),
+                        ],
                         true
                     );?>
                 "  onclick="<?php echo sprintf($paginatorOnclick, $this->current - 1);?>">
@@ -63,13 +63,13 @@ $paginatorOnclick.= 'document.forms[\'form_'.$this->gridId.'\'].submit(); return
             
             if($this->current != $page){
                 $url = $this->url($this->matchedRouteName, 
-                    array(),
-                    array(
-                        'query' => array_merge($this->activeParameters, array(
+                    [],
+                    [
+                        'query' => array_merge($this->activeParameters, [
                                 $this->parameterNames['currentPage'] => $page
-                            )
+                            ]
                         )
-                    ),
+                    ],
                     true
                 );
             } else{
@@ -88,13 +88,13 @@ $paginatorOnclick.= 'document.forms[\'form_'.$this->gridId.'\'].submit(); return
             <li>
                 <a href="<?php echo 
                     $this->url($this->matchedRouteName, 
-                        array(),
-                        array(
-                            'query' => array_merge($this->activeParameters, array(
+                        [],
+                        [
+                            'query' => array_merge($this->activeParameters, [
                                     $this->parameterNames['currentPage'] => $this->current + 1
-                                )
+                                ]
                             )
-                        ),
+                        ],
                         true
                     );?>
                 " onclick="<?php echo sprintf($paginatorOnclick, $this->current + 1);?>">
@@ -113,13 +113,13 @@ $paginatorOnclick.= 'document.forms[\'form_'.$this->gridId.'\'].submit(); return
             <li>
                 <a href="<?php echo 
                     $this->url($this->matchedRouteName, 
-                        array(),
-                        array(
-                            'query' => array_merge($this->activeParameters, array(
+                        [],
+                        [
+                            'query' => array_merge($this->activeParameters, [
                                     $this->parameterNames['currentPage'] => $this->pageCount
-                                )
+                                ]
                             )
-                        ),
+                        ],
                         true
                     );?>
                 " onclick="<?php echo sprintf($paginatorOnclick, $this->pageCount);?>">

--- a/view/zfc-datagrid/renderer/jqGrid/layout.phtml
+++ b/view/zfc-datagrid/renderer/jqGrid/layout.phtml
@@ -9,16 +9,16 @@ $paginator = $this->paginator;
 
 $parameterNames = $this->optionsRenderer['parameterNames'];
 
-$url = $this->url(null, array(), array(), true);
+$url = $this->url(null, [], [], true);
 if($this->overwriteUrl != ''){
     $url = $this->overwriteUrl;
 }
-$parametersHtml = array();
+$parametersHtml = [];
 foreach($this->parameters as $name => $value){
     $parametersHtml []= $name.': \''.$value.'\'';
 }
 
-$tableClasses = array();
+$tableClasses = [];
 $rowClickLink = '';
 
 if($this->rowClickAction){

--- a/view/zfc-datagrid/toolbar/export.phtml
+++ b/view/zfc-datagrid/toolbar/export.phtml
@@ -1,5 +1,5 @@
 <?php 
-$url = $this->url(null, array(), array(), true);
+$url = $this->url(null, [], [], true);
 if($this->overwriteUrl != ''){
     $url = $this->overwriteUrl;
 }


### PR DESCRIPTION
Solution for issue #268.

### Solution for Action Button
I've used the ZF2 view helper URL inside `ZfcDatagrid\Renderer\BootstrapTable\View\Helper\TableRow` since that is already a view helper itself. If you've got a router setup this works out of the box.

You can now do the following:

```php
$action->setRoute( 'myRoute' );
$action->setRouteParams( [
    'month' => $column->getColumnValuePlaceholder( 'month' ),
    'id'    => $column->getColumnValuePlaceholder( 'id' ),
] );
```

### Solution for Select Column
Set the router you want to use in the Datagrid:

```php
$datagrid->setRouter( $serviceLocator->get( 'router' ) );
```

Then set a route on a link formatter and provide that formatter to the column:

```php
$formatter = new \ZfcDatagrid\Column\Formatter\Link();
$formatter->setRoute( 'myroute' );
$formatter->setRouteParams( [
    'month' => $column->getColumnValuePlaceholder( 'month' ),
    'id'    => $column->getColumnValuePlaceholder( 'id' ),
] );
$col1->addFormatter( $formatter );
```