### PR TITLE
drop PHP5 and HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ language: php
 sudo: false
 
 php:
-  - 5.6
   - 7
   - 7.1
-  - hhvm
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     }],
 
     "require": {
-        "php": "~5.6|~7.0",
+        "php": "^7.0",
         
         "zendframework/zend-mvc": "^3.0",
         "zendframework/zend-session": "^2.5",


### PR DESCRIPTION
drop PHP5
about hhvm i tried it and it works but composer will not run with it, if we set the config of hhvm to php7 mode.

example error https://travis-ci.org/kokspflanze/ZfcDatagrid/jobs/204423491#L688-L692

i think the problem is that the phar file support php5.3+ and the fix for that is in a higher symfony-console version