### PR TITLE
Issue #280 Fixed

### DIFF
--- a/src/ZfcDatagrid/DataSource/Doctrine2/Filter.php
+++ b/src/ZfcDatagrid/DataSource/Doctrine2/Filter.php
@@ -121,8 +121,8 @@ class Filter
                     break;
 
                 case DatagridFilter::BETWEEN:
-                    $minParameterName = ':'.str_replace('.', '', $colString.'0');
-                    $maxParameterName = ':'.str_replace('.', '', $colString.'1');
+                    $minParameterName = ':' . str_replace('.', '', $col->getUniqueId() . '0');
+                    $maxParameterName = ':' . str_replace('.', '', $col->getUniqueId() . '1');
 
                     $wheres[] = $expr->between($colString, $minParameterName, $maxParameterName);
 


### PR DESCRIPTION
Wrong usage of colString in BETWEEN case for parametername instead of uniqueId used else where.
This causing  lexer generate issue when there is usage of expression in column. 